### PR TITLE
Changed domain of lv:isil from foaf:Organization to foaf:Agent

### DIFF
--- a/lobid-vocab.ttl
+++ b/lobid-vocab.ttl
@@ -81,7 +81,7 @@ lv:isil
    rdfs:comment "International Standard Identifier for Libraries and Related Organizations (ISIL). 'An ISIL identifies an organization, i.e., a library or a related organization, or one of its subordinate units, which is responsible for an action or service in a bibliographic environment (e.g. creation of machine-readable information). It can be used to identify the originator or holder of a resource (e.g. library material).'"@en ;
    rdfs:subPropertyOf dct:identifier ;
    rdfs:seeAlso <http://biblstandard.dk/isil/scope.htm> ;
-   rdfs:domain foaf:Organization ;
+   rdfs:domain foaf:Agent ;
    rdfs:range rdfs:Literal .
 
 # <http://purl.org/lobid/lv#stocksize>


### PR DESCRIPTION
There are entities related to an ISIL which are not organizations.
