### PR TITLE
Adjust namespace for NWBib Sachsystematik

### DIFF
--- a/nwbib/nwbib.ttl
+++ b/nwbib/nwbib.ttl
@@ -14,7260 +14,7260 @@
     dct:modified "2022-01-13" ;
     dct:publisher <http://lobid.org/organisations/DE-605> ;
     vann:preferredNamespaceUri "https://nwbib.de/subjects#" ;
-    skos:hasTopConcept :s1, :s2, :s4, :s5, :s6, :s7, :s8 .
+    skos:hasTopConcept :N1, :N2, :N4, :N5, :N6, :N7, :N8 .
 
-:s1
+:N1
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s100000 ,:s120000, :s140000, :s160000;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N100000 ,:N120000, :N140000, :N160000;
     skos:notation "1" ;
     skos:prefLabel "Landeskunde (allgemein. Geo-u. Biowissenschaften)"@de .
 
-:s2
+:N2
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s200000 ,:s210000, :s220000, :s240000, :s260000;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N200000 ,:N210000, :N220000, :N240000, :N260000;
     skos:notation "2" ;
     skos:prefLabel "Landeskunde (historisch)"@de .
 
-:s4
+:N4
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s400000 ,:s420000, :s440000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N400000 ,:N420000, :N440000 ;
     skos:notation "4" ;
     skos:prefLabel "Staat. Politik. Verwaltung. Recht"@de .
 
-:s5
+:N5
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s500000 ,:s520000, :s530000, :s540000, :s550000, :s560000, :s570000, :s580000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N500000 ,:N520000, :N530000, :N540000, :N550000, :N560000, :N570000, :N580000 ;
     skos:notation "5" ;
     skos:prefLabel "Bevölkerung. Soziales. Wirtschaft. Raumordnung. Umweltschutz"@de .
 
-:s6
+:N6
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s610000 ,:s630000, :s650000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N610000 ,:N630000, :N650000 ;
     skos:notation "6" ;
     skos:prefLabel "Religion"@de .
 
-:s7
+:N7
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s700000 ,:s720000, :s730000, :s740000, :s760000 ,:s780000, :s790000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N700000 ,:N720000, :N730000, :N740000, :N760000 ,:N780000, :N790000 ;
     skos:notation "7" ;
     skos:prefLabel "Volkskunde. Gesellschaft. Kultur. Bildung"@de .
 
-:s8
+:N8
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s800000 ,:s820000, :s840000, :s860000, :s880000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N800000 ,:N820000, :N840000, :N860000, :N880000 ;
     skos:notation "8" ;
     skos:prefLabel "Künste. Medien"@de .
 
-:s100000
+:N100000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s1 ;
-    skos:narrower :s100100, :s101000, :s102000, :s106000, :s109000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N1 ;
+    skos:narrower :N100100, :N101000, :N102000, :N106000, :N109000 ;
     skos:notation "100000" ;
     skos:prefLabel "Allgemeine Landeskunde"@de .
 
-:s100100
+:N100100
     a skos:Concept ;
-    skos:broader :s100000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N100000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "100100" ;
     skos:prefLabel "Allgemeine Landeskunde - Allgemeines"@de .
 
-:s101000
+:N101000
     a skos:Concept ;
-    skos:broader :s100000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N100000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "101000" ;
     skos:prefLabel "Bibliographien"@de .
 
-:s102000
+:N102000
     a skos:Concept ;
-    skos:broader :s100000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s102060, :s102070, :s105000 ;
+    skos:broader :N100000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N102060, :N102070, :N105000 ;
     skos:notation "102000" ;
     skos:prefLabel "Landesbeschreibungen"@de .
 
-:s102060
+:N102060
     a skos:Concept ;
-    skos:broader :s102000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N102000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "102060" ;
     skos:prefLabel "Reiseberichte"@de .
 
-:s102070
+:N102070
     a skos:Concept ;
-    skos:broader :s102000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N102000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "102070" ;
     skos:prefLabel "Reise-, Stadt- und Wanderführer"@de .
 
-:s105000
+:N105000
     a skos:Concept ;
-    skos:broader :s102000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N102000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "105000" ;
     skos:prefLabel "Heimatpflege"@de .
 
-:s106000
+:N106000
     a skos:Concept ;
-    skos:broader :s100000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N100000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "106000" ;
     skos:prefLabel "Heimatvereine"@de .
 
-:s109000
+:N109000
     a skos:Concept ;
-    skos:broader :s100000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N100000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "109000" ;
     skos:prefLabel "Biographien"@de .
 
-:s120000
+:N120000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s1 ;
-    skos:narrower :s120100, :s122000, :s124000, :s126000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N1 ;
+    skos:narrower :N120100, :N122000, :N124000, :N126000 ;
     skos:notation "120000" ;
     skos:prefLabel "Kartographie. Geodäsie"@de .
 
-:s120100
+:N120100
     a skos:Concept ;
-    skos:broader :s120000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N120000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "120100" ;
     skos:prefLabel "Kartographie. Geodäsie - Allgemeines"@de .
 
-:s122000
+:N122000
     a skos:Concept ;
-    skos:broader :s120000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s122030, :s122050, :s122070 ;
+    skos:broader :N120000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N122030, :N122050, :N122070 ;
     skos:notation "122000" ;
     skos:prefLabel "Kartographie"@de .
 
-:s122030
+:N122030
     a skos:Concept ;
-    skos:broader :s122000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N122000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "122030" ;
     skos:prefLabel "Kartenauswertung"@de .
 
-:s122050
+:N122050
     a skos:Concept ;
-    skos:broader :s122000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N122000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "122050" ;
     skos:prefLabel "Computerkartographie"@de .
 
-:s122070
+:N122070
     a skos:Concept ;
-    skos:broader :s122000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N122000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "122070" ;
     skos:prefLabel "Luftbildauswertung"@de .
 
-:s124000
+:N124000
     a skos:Concept ;
-    skos:broader :s120000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N120000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "124000" ;
     skos:prefLabel "Geodäsie"@de .
 
-:s126000
+:N126000
     a skos:Concept ;
-    skos:broader :s120000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N120000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "126000" ;
     skos:prefLabel "Karten"@de .
 
-:s140000
+:N140000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s1 ;
-    skos:narrower :s140100, :s141000, :s141100, :s141200, :s141400, :s141600, :s142000, :s142100, :s142300, :s142500, :s146000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N1 ;
+    skos:narrower :N140100, :N141000, :N141100, :N141200, :N141400, :N141600, :N142000, :N142100, :N142300, :N142500, :N146000 ;
     skos:notation "140000" ;
     skos:prefLabel "Geowissenschaften"@de .
 
-:s140100
+:N140100
     a skos:Concept ;
-    skos:broader :s140000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N140000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "140100" ;
     skos:prefLabel "Geowissenschaften - Allgemeines"@de .
 
-:s141000
+:N141000
     a skos:Concept ;
-    skos:broader :s140000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s141020, :s141030, :s141040 ;
+    skos:broader :N140000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N141020, :N141030, :N141040 ;
     skos:notation "141000" ;
     skos:prefLabel "Geophysik"@de .
 
-:s141020
+:N141020
     a skos:Concept ;
-    skos:broader :s141000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141020" ;
     skos:prefLabel "Erdmagnetismus"@de .
 
-:s141030
+:N141030
     a skos:Concept ;
-    skos:broader :s141000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141030" ;
     skos:prefLabel "Schwerkraft"@de .
 
-:s141040
+:N141040
     a skos:Concept ;
-    skos:broader :s141000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141040" ;
     skos:prefLabel "Erdbeben"@de .
 
-:s141100
+:N141100
     a skos:Concept ;
-    skos:broader :s140000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N140000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141100" ;
     skos:prefLabel "Geochemie"@de .
 
-:s141200
+:N141200
     a skos:Concept ;
-    skos:broader :s140000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s141210, :s141220, :s141230, :s141240 ;
+    skos:broader :N140000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N141210, :N141220, :N141230, :N141240 ;
     skos:notation "141200" ;
     skos:prefLabel "Geologie"@de .
 
-:s141210
+:N141210
     a skos:Concept ;
-    skos:broader :s141200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141210" ;
     skos:prefLabel "Historische Geologie"@de .
 
-:s141220
+:N141220
     a skos:Concept ;
-    skos:broader :s141200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s141225 ;
+    skos:broader :N141200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N141225 ;
     skos:notation "141220" ;
     skos:prefLabel "Tektonik"@de .
 
-:s141225
+:N141225
     a skos:Concept ;
-    skos:broader :s141220 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141220 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141225" ;
     skos:prefLabel "Vulkanismus"@de .
 
-:s141230
+:N141230
     a skos:Concept ;
-    skos:broader :s141200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141230" ;
     skos:prefLabel "Ingenieurgeologie"@de .
 
-:s141240
+:N141240
     a skos:Concept ;
-    skos:broader :s141200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141240" ;
     skos:prefLabel "Stratigraphie"@de .
 
-:s141400
+:N141400
     a skos:Concept ;
-    skos:broader :s140000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s141420, :s141430, :s141450, :s141460 ;
+    skos:broader :N140000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N141420, :N141430, :N141450, :N141460 ;
     skos:notation "141400" ;
     skos:prefLabel "Mineralogie. Gesteinskunde"@de .
 
-:s141420
+:N141420
     a skos:Concept ;
-    skos:broader :s141400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s141425 ;
+    skos:broader :N141400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N141425 ;
     skos:notation "141420" ;
     skos:prefLabel "Mineralogie"@de .
 
-:s141425
+:N141425
     a skos:Concept ;
-    skos:broader :s141420 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141420 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141425" ;
     skos:prefLabel "Einzelne Minerale"@de .
 
-:s141430
+:N141430
     a skos:Concept ;
-    skos:broader :s141400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s141435 ;
+    skos:broader :N141400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N141435 ;
     skos:notation "141430" ;
     skos:prefLabel "Gesteinskunde"@de .
 
-:s141435
+:N141435
     a skos:Concept ;
-    skos:broader :s141430 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141430 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141435" ;
     skos:prefLabel "Einzelne Gesteine"@de .
 
-:s141450
+:N141450
     a skos:Concept ;
-    skos:broader :s141400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141450" ;
     skos:prefLabel "Lagerstättenkunde"@de .
 
-:s141460
+:N141460
     a skos:Concept ;
-    skos:broader :s141400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141460" ;
     skos:prefLabel "Mineralquellen. Thermalquellen"@de .
 
-:s141600
+:N141600
     a skos:Concept ;
-    skos:broader :s140000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s141620, :s141630, :s141640 ;
+    skos:broader :N140000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N141620, :N141630, :N141640 ;
     skos:notation "141600" ;
     skos:prefLabel "Paläontologie"@de .
 
-:s141620
+:N141620
     a skos:Concept ;
-    skos:broader :s141600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s141622, :s141624 ;
+    skos:broader :N141600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N141622, :N141624 ;
     skos:notation "141620" ;
     skos:prefLabel "Paläobotanik"@de .
 
-:s141622
+:N141622
     a skos:Concept ;
-    skos:broader :s141620 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141620 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141622" ;
     skos:prefLabel "Fossile Kryptogamen"@de .
 
-:s141624
+:N141624
     a skos:Concept ;
-    skos:broader :s141620 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141620 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141624" ;
     skos:prefLabel "Fossile Samenpflanzen"@de .
 
-:s141630
+:N141630
     a skos:Concept ;
-    skos:broader :s141600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s141632, :s141634 ;
+    skos:broader :N141600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N141632, :N141634 ;
     skos:notation "141630" ;
     skos:prefLabel "Paläozoologie"@de .
 
-:s141632
+:N141632
     a skos:Concept ;
-    skos:broader :s141630 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141630 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141632" ;
     skos:prefLabel "Fossile Wirbellose"@de .
 
-:s141634
+:N141634
     a skos:Concept ;
-    skos:broader :s141630 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141630 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141634" ;
     skos:prefLabel "Fossile Wirbeltiere"@de .
 
-:s141640
+:N141640
     a skos:Concept ;
-    skos:broader :s141600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N141600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "141640" ;
     skos:prefLabel "Mikropaläontologie"@de .
 
-:s142000
+:N142000
     a skos:Concept ;
-    skos:broader :s140000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s142020, :s142040, :s142050, :s142060, :s142070, :s142080 ;
+    skos:broader :N140000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N142020, :N142040, :N142050, :N142060, :N142070, :N142080 ;
     skos:notation "142000" ;
     skos:prefLabel "Bodenkunde"@de .
 
-:s142020
+:N142020
     a skos:Concept ;
-    skos:broader :s142000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s142025 ;
+    skos:broader :N142000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N142025 ;
     skos:notation "142020" ;
     skos:prefLabel "Bodenentwicklung"@de .
 
-:s142025
+:N142025
     a skos:Concept ;
-    skos:broader :s142020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142025" ;
     skos:prefLabel "Verwitterung"@de .
 
-:s142040
+:N142040
     a skos:Concept ;
-    skos:broader :s142000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142040" ;
     skos:prefLabel "Bodenbiologie"@de .
 
-:s142050
+:N142050
     a skos:Concept ;
-    skos:broader :s142000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142050" ;
     skos:prefLabel "Bodenmechanik"@de .
 
-:s142060
+:N142060
     a skos:Concept ;
-    skos:broader :s142000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142060" ;
     skos:prefLabel "Bodenchemie"@de .
 
-:s142070
+:N142070
     a skos:Concept ;
-    skos:broader :s142000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142070" ;
     skos:prefLabel "Tonminerale"@de .
 
-:s142080
+:N142080
     a skos:Concept ;
-    skos:broader :s142000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142080" ;
     skos:prefLabel "Angewandte Bodenkunde"@de .
 
-:s142100
+:N142100
     a skos:Concept ;
-    skos:broader :s140000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s142110, :s142120, :s142130, :s142140, :s142170, :s142180, :s142190 ;
+    skos:broader :N140000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N142110, :N142120, :N142130, :N142140, :N142170, :N142180, :N142190 ;
     skos:notation "142100" ;
     skos:prefLabel "Geomorphologie"@de .
 
-:s142110
+:N142110
     a skos:Concept ;
-    skos:broader :s142100 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142100 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142110" ;
     skos:prefLabel "Oberflächenformen"@de .
 
-:s142120
+:N142120
     a skos:Concept ;
-    skos:broader :s142100 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s142125 ;
+    skos:broader :N142100 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N142125 ;
     skos:notation "142120" ;
     skos:prefLabel "Abtragung"@de .
 
-:s142125
+:N142125
     a skos:Concept ;
-    skos:broader :s142120 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142120 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142125" ;
     skos:prefLabel "Sedimentation"@de .
 
-:s142130
+:N142130
     a skos:Concept ;
-    skos:broader :s142100 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142100 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142130" ;
     skos:prefLabel "Klimamorphologie"@de .
 
-:s142140
+:N142140
     a skos:Concept ;
-    skos:broader :s142100 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142100 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142140" ;
     skos:prefLabel "Glazialmorphologie"@de .
 
-:s142170
+:N142170
     a skos:Concept ;
-    skos:broader :s142100 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142100 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142170" ;
     skos:prefLabel "Karst"@de .
 
-:s142180
+:N142180
     a skos:Concept ;
-    skos:broader :s142100 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142100 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142180" ;
     skos:prefLabel "Höhlen"@de .
 
-:s142190
+:N142190
     a skos:Concept ;
-    skos:broader :s142100 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142100 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142190" ;
     skos:prefLabel "Angewandte Geomorphologie"@de .
 
-:s142300
+:N142300
     a skos:Concept ;
-    skos:broader :s140000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s142310, :s142320, :s142330, :s142340, :s142350, :s142360, :s142370, :s142380, :s142390 ;
+    skos:broader :N140000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N142310, :N142320, :N142330, :N142340, :N142350, :N142360, :N142370, :N142380, :N142390 ;
     skos:notation "142300" ;
     skos:prefLabel "Wasser"@de .
 
-:s142310
+:N142310
     a skos:Concept ;
-    skos:broader :s142300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142310" ;
     skos:prefLabel "Wasserrecht"@de .
 
-:s142320
+:N142320
     a skos:Concept ;
-    skos:broader :s142300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142320" ;
     skos:prefLabel "Fließgewässer"@de .
 
-:s142330
+:N142330
     a skos:Concept ;
-    skos:broader :s142300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s142335 ;
+    skos:broader :N142300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N142335 ;
     skos:notation "142330" ;
     skos:prefLabel "Seen"@de .
 
-:s142335
+:N142335
     a skos:Concept ;
-    skos:broader :s142330 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142330 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142335" ;
     skos:prefLabel "Kleingewässer"@de .
 
-:s142340
+:N142340
     a skos:Concept ;
-    skos:broader :s142300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142340" ;
     skos:prefLabel "Moore"@de .
 
-:s142350
+:N142350
     a skos:Concept ;
-    skos:broader :s142300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s142352 ;
+    skos:broader :N142300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N142352 ;
     skos:notation "142350" ;
     skos:prefLabel "Hydrogeologie"@de .
 
-:s142352
+:N142352
     a skos:Concept ;
-    skos:broader :s142350 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142350 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142352" ;
     skos:prefLabel "Bodenwasser. Grundwasser"@de .
 
-:s142360
+:N142360
     a skos:Concept ;
-    skos:broader :s142300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142360" ;
     skos:prefLabel "Wasserhaushalt"@de .
 
-:s142370
+:N142370
     a skos:Concept ;
-    skos:broader :s142300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s142372, :s142373, :s142375 ;
+    skos:broader :N142300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N142372, :N142373, :N142375 ;
     skos:notation "142370" ;
     skos:prefLabel "Wasserwirtschaft"@de .
 
-:s142372
+:N142372
     a skos:Concept ;
-    skos:broader :s142370 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142370 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142372" ;
     skos:prefLabel "Trinkwasserversorgung"@de .
 
-:s142373
+:N142373
     a skos:Concept ;
-    skos:broader :s142370 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142370 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142373" ;
     skos:prefLabel "Trinkwasseraufbereitung"@de .
 
-:s142375
+:N142375
     a skos:Concept ;
-    skos:broader :s142370 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142370 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142375" ;
     skos:prefLabel "Brauchwasser"@de .
 
-:s142380
+:N142380
     a skos:Concept ;
-    skos:broader :s142300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s142382 ;
+    skos:broader :N142300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N142382 ;
     skos:notation "142380" ;
     skos:prefLabel "Hydrobiologie"@de .
 
-:s142382
+:N142382
     a skos:Concept ;
-    skos:broader :s142380 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142380 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142382" ;
     skos:prefLabel "Wasseranalysen"@de .
 
-:s142390
+:N142390
     a skos:Concept ;
-    skos:broader :s142300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142390" ;
     skos:prefLabel "Wasserstatistik"@de .
 
-:s142500
+:N142500
     a skos:Concept ;
-    skos:broader :s140000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s142520, :s142530, :s142540, :s142560, :s142570 ;
+    skos:broader :N140000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N142520, :N142530, :N142540, :N142560, :N142570 ;
     skos:notation "142500" ;
     skos:prefLabel "Klima"@de .
 
-:s142520
+:N142520
     a skos:Concept ;
-    skos:broader :s142500 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s142522, :s142523, :s142524, :s142526 ;
+    skos:broader :N142500 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N142522, :N142523, :N142524, :N142526 ;
     skos:notation "142520" ;
     skos:prefLabel "Klimaelemente"@de .
 
-:s142522
+:N142522
     a skos:Concept ;
-    skos:broader :s142520 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142520 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142522" ;
     skos:prefLabel "Strahlung"@de .
 
-:s142523
+:N142523
     a skos:Concept ;
-    skos:broader :s142520 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142520 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142523" ;
     skos:prefLabel "Temperatur"@de .
 
-:s142524
+:N142524
     a skos:Concept ;
-    skos:broader :s142520 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142520 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142524" ;
     skos:prefLabel "Niederschlag"@de .
 
-:s142526
+:N142526
     a skos:Concept ;
-    skos:broader :s142520 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142520 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142526" ;
     skos:prefLabel "Luft"@de .
 
-:s142530
+:N142530
     a skos:Concept ;
-    skos:broader :s142500 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142500 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142530" ;
     skos:prefLabel "Klimatologie"@de .
 
-:s142540
+:N142540
     a skos:Concept ;
-    skos:broader :s142500 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s142541 ;
+    skos:broader :N142500 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N142541 ;
     skos:notation "142540" ;
     skos:prefLabel "Wetterdienst"@de .
 
-:s142541
+:N142541
     a skos:Concept ;
-    skos:broader :s142540 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142540 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142541" ;
     skos:prefLabel "Wetterlagen"@de .
 
-:s142560
+:N142560
     a skos:Concept ;
-    skos:broader :s142500 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142500 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142560" ;
     skos:prefLabel "Klimaänderungen"@de .
 
-:s142570
+:N142570
     a skos:Concept ;
-    skos:broader :s142500 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N142500 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "142570" ;
     skos:prefLabel "Paläoklimatologie"@de .
 
-:s146000
+:N146000
     a skos:Concept ;
-    skos:broader :s140000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N140000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "146000" ;
     skos:prefLabel "Geoökologie"@de .
 
-:s160000
+:N160000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s1 ;
-    skos:narrower :s160100, :s161000, :s162000, :s163000, :s164000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N1 ;
+    skos:narrower :N160100, :N161000, :N162000, :N163000, :N164000 ;
     skos:notation "160000" ;
     skos:prefLabel "Biowissenschaften"@de .
 
-:s160100
+:N160100
     a skos:Concept ;
-    skos:broader :s160000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N160000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "160100" ;
     skos:prefLabel "Biowissenschaften - Allgemeines"@de .
 
-:s161000
+:N161000
     a skos:Concept ;
-    skos:broader :s160000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s161020, :s161030, :s161040, :s161050 ;
+    skos:broader :N160000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N161020, :N161030, :N161040, :N161050 ;
     skos:notation "161000" ;
     skos:prefLabel "Biologie"@de .
 
-:s161020
+:N161020
     a skos:Concept ;
-    skos:broader :s161000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N161000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "161020" ;
     skos:prefLabel "Biogeographie"@de .
 
-:s161030
+:N161030
     a skos:Concept ;
-    skos:broader :s161000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N161000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "161030" ;
     skos:prefLabel "Ökologie"@de .
 
-:s161040
+:N161040
     a skos:Concept ;
-    skos:broader :s161000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N161000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "161040" ;
     skos:prefLabel "Lebensgemeinschaften von Tieren und Pflanzen"@de .
 
-:s161050
+:N161050
     a skos:Concept ;
-    skos:broader :s161000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N161000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "161050" ;
     skos:prefLabel "Mikrobiologie"@de .
 
-:s162000
+:N162000
     a skos:Concept ;
-    skos:broader :s160000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s162020, :s162030, :s162040 ;
+    skos:broader :N160000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N162020, :N162030, :N162040 ;
     skos:notation "162000" ;
     skos:prefLabel "Pflanzen"@de .
 
-:s162020
+:N162020
     a skos:Concept ;
-    skos:broader :s162000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N162000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "162020" ;
     skos:prefLabel "Pflanzengeographie"@de .
 
-:s162030
+:N162030
     a skos:Concept ;
-    skos:broader :s162000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N162000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "162030" ;
     skos:prefLabel "Kryptogamen"@de .
 
-:s162040
+:N162040
     a skos:Concept ;
-    skos:broader :s162000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N162000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "162040" ;
     skos:prefLabel "Samenpflanzen"@de .
 
-:s163000
+:N163000
     a skos:Concept ;
-    skos:broader :s160000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s163010, :s163020, :s163030, :s163040, :s163050, :s163060, :s163070, :s163080, :s163090 ;
+    skos:broader :N160000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N163010, :N163020, :N163030, :N163040, :N163050, :N163060, :N163070, :N163080, :N163090 ;
     skos:notation "163000" ;
     skos:prefLabel "Tiere"@de .
 
-:s163010
+:N163010
     a skos:Concept ;
-    skos:broader :s163000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N163000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "163010" ;
     skos:prefLabel "Tiergeographie"@de .
 
-:s163020
+:N163020
     a skos:Concept ;
-    skos:broader :s163000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N163000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "163020" ;
     skos:prefLabel "Wirbellose"@de .
 
-:s163030
+:N163030
     a skos:Concept ;
-    skos:broader :s163000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N163000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "163030" ;
     skos:prefLabel "Insekten. Spinnen"@de .
 
-:s163040
+:N163040
     a skos:Concept ;
-    skos:broader :s163000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N163000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "163040" ;
     skos:prefLabel "Wirbeltiere"@de .
 
-:s163050
+:N163050
     a skos:Concept ;
-    skos:broader :s163000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N163000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "163050" ;
     skos:prefLabel "Fische"@de .
 
-:s163060
+:N163060
     a skos:Concept ;
-    skos:broader :s163000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N163000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "163060" ;
     skos:prefLabel "Lurche"@de .
 
-:s163070
+:N163070
     a skos:Concept ;
-    skos:broader :s163000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N163000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "163070" ;
     skos:prefLabel "Reptilien"@de .
 
-:s163080
+:N163080
     a skos:Concept ;
-    skos:broader :s163000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N163000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "163080" ;
     skos:prefLabel "Vögel"@de .
 
-:s163090
+:N163090
     a skos:Concept ;
-    skos:broader :s163000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N163000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "163090" ;
     skos:prefLabel "Säugetiere"@de .
 
-:s164000
+:N164000
     a skos:Concept ;
-    skos:broader :s160000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s164030, :s164040 ;
+    skos:broader :N160000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N164030, :N164040 ;
     skos:notation "164000" ;
     skos:prefLabel "Biologische Anthropologie"@de .
 
-:s164030
+:N164030
     a skos:Concept ;
-    skos:broader :s164000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N164000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "164030" ;
     skos:prefLabel "Skelettfunde"@de .
 
-:s164040
+:N164040
     a skos:Concept ;
-    skos:broader :s164000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N164000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "164040" ;
     skos:prefLabel "Paläanthropologie"@de .
 
-:s200000
+:N200000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s2 ;
-    skos:narrower :s200100, :s202000, :s202500, :s203000, :s203500, :s204000, :s205000, :s206000, :s207000, :s208000, :s208500, :s209000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N2 ;
+    skos:narrower :N200100, :N202000, :N202500, :N203000, :N203500, :N204000, :N205000, :N206000, :N207000, :N208000, :N208500, :N209000 ;
     skos:notation "200000" ;
     skos:prefLabel "Historische Hilfswissenschaften"@de .
 
-:s200100
+:N200100
     a skos:Concept ;
-    skos:broader :s200000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N200000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "200100" ;
     skos:prefLabel "Historische Hilfswissenschaften - Allgemeines"@de .
 
-:s202000
+:N202000
     a skos:Concept ;
-    skos:broader :s200000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N200000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "202000" ;
     skos:prefLabel "Chronologie"@de .
 
-:s202500
+:N202500
     a skos:Concept ;
-    skos:broader :s200000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N200000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "202500" ;
     skos:prefLabel "Metrologie"@de .
 
-:s203000
+:N203000
     a skos:Concept ;
-    skos:broader :s200000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N200000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "203000" ;
     skos:prefLabel "Urkundenlehre"@de .
 
-:s203500
+:N203500
     a skos:Concept ;
-    skos:broader :s200000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N200000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "203500" ;
     skos:prefLabel "Paläographie"@de .
 
-:s204000
+:N204000
     a skos:Concept ;
-    skos:broader :s200000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N200000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "204000" ;
     skos:prefLabel "Siegelkunde"@de .
 
-:s205000
+:N205000
     a skos:Concept ;
-    skos:broader :s200000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s205020, :s205040 ;
+    skos:broader :N200000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N205020, :N205040 ;
     skos:notation "205000" ;
     skos:prefLabel "Numismatik"@de .
 
-:s205020
+:N205020
     a skos:Concept ;
-    skos:broader :s205000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N205000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "205020" ;
     skos:prefLabel "Geld. Münzen"@de .
 
-:s205040
+:N205040
     a skos:Concept ;
-    skos:broader :s205000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N205000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "205040" ;
     skos:prefLabel "Münzfunde"@de .
 
-:s206000
+:N206000
     a skos:Concept ;
-    skos:broader :s200000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N200000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "206000" ;
     skos:prefLabel "Epigraphik"@de .
 
-:s207000
+:N207000
     a skos:Concept ;
-    skos:broader :s200000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s207020 ;
+    skos:broader :N200000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N207020 ;
     skos:notation "207000" ;
     skos:prefLabel "Genealogie"@de .
 
-:s207020
+:N207020
     a skos:Concept ;
-    skos:broader :s207000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N207000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "207020" ;
     skos:prefLabel "Einzelne Familien"@de .
 
-:s208000
+:N208000
     a skos:Concept ;
-    skos:broader :s200000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N200000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "208000" ;
     skos:prefLabel "Heraldik"@de .
 
-:s208500
+:N208500
     a skos:Concept ;
-    skos:broader :s200000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N200000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "208500" ;
     skos:prefLabel "Flaggen"@de .
 
-:s209000
+:N209000
     a skos:Concept ;
-    skos:broader :s200000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N200000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "209000" ;
     skos:prefLabel "Orden. Ehrenzeichen"@de .
 
-:s210000
+:N210000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s2 ;
-    skos:narrower :s210100, :s213000, :s217000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N2 ;
+    skos:narrower :N210100, :N213000, :N217000 ;
     skos:notation "210000" ;
     skos:prefLabel "Archive. Museen"@de .
 
-:s210100
+:N210100
     a skos:Concept ;
-    skos:broader :s210000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N210000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "210100" ;
     skos:prefLabel "Archive. Museen - Allgemeines"@de .
 
-:s213000
+:N213000
     a skos:Concept ;
-    skos:broader :s210000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s213010, :s213020, :s213030, :s213040, :s213050, :s213060, :s213070, :s213080, :s213090 ;
+    skos:broader :N210000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N213010, :N213020, :N213030, :N213040, :N213050, :N213060, :N213070, :N213080, :N213090 ;
     skos:notation "213000" ;
     skos:prefLabel "Archive"@de .
 
-:s213010
+:N213010
     a skos:Concept ;
-    skos:broader :s213000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N213000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "213010" ;
     skos:prefLabel "Staatsarchive"@de .
 
-:s213020
+:N213020
     a skos:Concept ;
-    skos:broader :s213000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N213000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "213020" ;
     skos:prefLabel "Kreisarchive. Stadtarchive"@de .
 
-:s213030
+:N213030
     a skos:Concept ;
-    skos:broader :s213000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N213000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "213030" ;
     skos:prefLabel "Kirchenarchive"@de .
 
-:s213040
+:N213040
     a skos:Concept ;
-    skos:broader :s213000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N213000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "213040" ;
     skos:prefLabel "Archive wissenschaftlicher und kultureller Einrichtungen"@de .
 
-:s213050
+:N213050
     a skos:Concept ;
-    skos:broader :s213000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N213000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "213050" ;
     skos:prefLabel "Parteiarchive"@de .
 
-:s213060
+:N213060
     a skos:Concept ;
-    skos:broader :s213000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N213000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "213060" ;
     skos:prefLabel "Vereinsarchive"@de .
 
-:s213070
+:N213070
     a skos:Concept ;
-    skos:broader :s213000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N213000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "213070" ;
     skos:prefLabel "Pressearchive. Rundfunkarchive"@de .
 
-:s213080
+:N213080
     a skos:Concept ;
-    skos:broader :s213000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s213084 ;
+    skos:broader :N213000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N213084 ;
     skos:notation "213080" ;
     skos:prefLabel "Wirtschaftsarchive"@de .
 
-:s213084
+:N213084
     a skos:Concept ;
-    skos:broader :s213080 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N213080 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "213084" ;
     skos:prefLabel "Firmenarchive"@de .
 
-:s213090
+:N213090
     a skos:Concept ;
-    skos:broader :s213000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N213000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "213090" ;
     skos:prefLabel "Familienarchive"@de .
 
-:s217000
+:N217000
     a skos:Concept ;
-    skos:broader :s210000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s217010, :s217020, :s217030, :s217040, :s217050, :s217090 ;
+    skos:broader :N210000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N217010, :N217020, :N217030, :N217040, :N217050, :N217090 ;
     skos:notation "217000" ;
     skos:prefLabel "Museen und Sammlungen"@de .
 
-:s217010
+:N217010
     a skos:Concept ;
-    skos:broader :s217000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N217000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "217010" ;
     skos:prefLabel "Museumspädagogik"@de .
 
-:s217020
+:N217020
     a skos:Concept ;
-    skos:broader :s217000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N217000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "217020" ;
     skos:prefLabel "Naturkundemuseen"@de .
 
-:s217030
+:N217030
     a skos:Concept ;
-    skos:broader :s217000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N217000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "217030" ;
     skos:prefLabel "Museen für Handwerk und Technik"@de .
 
-:s217040
+:N217040
     a skos:Concept ;
-    skos:broader :s217000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s217042 ;
+    skos:broader :N217000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N217042 ;
     skos:notation "217040" ;
     skos:prefLabel "Historische Museen"@de .
 
-:s217042
+:N217042
     a skos:Concept ;
-    skos:broader :s217040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N217040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "217042" ;
     skos:prefLabel "Heimatmuseen"@de .
 
-:s217050
+:N217050
     a skos:Concept ;
-    skos:broader :s217000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N217000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "217050" ;
     skos:prefLabel "Volkskundemuseen"@de .
 
-:s217090
+:N217090
     a skos:Concept ;
-    skos:broader :s217000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N217000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "217090" ;
     skos:prefLabel "Sonstige Museen und Sammlungen"@de .
 
-:s220000
+:N220000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s2 ;
-    skos:narrower :s220100, :s220500, :s221000, :s222000, :s223000, :s224000, :s225000, :s226000, :s227000, :s228000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N2 ;
+    skos:narrower :N220100, :N220500, :N221000, :N222000, :N223000, :N224000, :N225000, :N226000, :N227000, :N228000 ;
     skos:notation "220000" ;
     skos:prefLabel "Vor- und Frühgeschichte. Archäologie"@de .
 
-:s220100
+:N220100
     a skos:Concept ;
-    skos:broader :s220000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N220000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "220100" ;
     skos:prefLabel "Vor- und Frühgeschichte. Archäologie - Allgemeines"@de .
 
-:s220500
+:N220500
     a skos:Concept ;
-    skos:broader :s220000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N220000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "220500" ;
     skos:prefLabel "Archäologie"@de .
 
-:s221000
+:N221000
     a skos:Concept ;
-    skos:broader :s220000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N220000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "221000" ;
     skos:prefLabel "Vor- und Frühgeschichte"@de .
 
-:s222000
+:N222000
     a skos:Concept ;
-    skos:broader :s220000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N220000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "222000" ;
     skos:prefLabel "Paläolithikum. Mesolithikum"@de .
 
-:s223000
+:N223000
     a skos:Concept ;
-    skos:broader :s220000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s223020, :s223030, :s223040, :s223050, :s223060, :s223070 ;
+    skos:broader :N220000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N223020, :N223030, :N223040, :N223050, :N223060, :N223070 ;
     skos:notation "223000" ;
     skos:prefLabel "Neolithikum"@de .
 
-:s223020
+:N223020
     a skos:Concept ;
-    skos:broader :s223000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N223000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "223020" ;
     skos:prefLabel "Bandkeramische Kultur"@de .
 
-:s223030
+:N223030
     a skos:Concept ;
-    skos:broader :s223000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N223000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "223030" ;
     skos:prefLabel "Rössener Kultur"@de .
 
-:s223040
+:N223040
     a skos:Concept ;
-    skos:broader :s223000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N223000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "223040" ;
     skos:prefLabel "Michelsberger Kultur"@de .
 
-:s223050
+:N223050
     a skos:Concept ;
-    skos:broader :s223000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N223000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "223050" ;
     skos:prefLabel "Megalithkultur"@de .
 
-:s223060
+:N223060
     a skos:Concept ;
-    skos:broader :s223000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N223000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "223060" ;
     skos:prefLabel "Schnurkeramische Kultur"@de .
 
-:s223070
+:N223070
     a skos:Concept ;
-    skos:broader :s223000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N223000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "223070" ;
     skos:prefLabel "Glockenbecherkultur"@de .
 
-:s224000
+:N224000
     a skos:Concept ;
-    skos:broader :s220000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s224050, :s224060 ;
+    skos:broader :N220000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N224050, :N224060 ;
     skos:notation "224000" ;
     skos:prefLabel "Bronzezeit"@de .
 
-:s224050
+:N224050
     a skos:Concept ;
-    skos:broader :s224000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N224000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "224050" ;
     skos:prefLabel "Hügelgräberkultur"@de .
 
-:s224060
+:N224060
     a skos:Concept ;
-    skos:broader :s224000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N224000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "224060" ;
     skos:prefLabel "Urnenfelderkultur"@de .
 
-:s225000
+:N225000
     a skos:Concept ;
-    skos:broader :s220000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s225020, :s225030, :s225040, :s225050 ;
+    skos:broader :N220000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N225020, :N225030, :N225040, :N225050 ;
     skos:notation "225000" ;
     skos:prefLabel "Vorrömische Eisenzeit"@de .
 
-:s225020
+:N225020
     a skos:Concept ;
-    skos:broader :s225000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N225000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "225020" ;
     skos:prefLabel "Hallstattkultur"@de .
 
-:s225030
+:N225030
     a skos:Concept ;
-    skos:broader :s225000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N225000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "225030" ;
     skos:prefLabel "Latène-Zeit"@de .
 
-:s225040
+:N225040
     a skos:Concept ;
-    skos:broader :s225000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N225000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "225040" ;
     skos:prefLabel "Kelten"@de .
 
-:s225050
+:N225050
     a skos:Concept ;
-    skos:broader :s225000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N225000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "225050" ;
     skos:prefLabel "Germanen"@de .
 
-:s226000
+:N226000
     a skos:Concept ;
-    skos:broader :s220000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s226010, :s226020, :s226030, :s226040, :s226050 ;
+    skos:broader :N220000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N226010, :N226020, :N226030, :N226040, :N226050 ;
     skos:notation "226000" ;
     skos:prefLabel "Römerzeit"@de .
 
-:s226010
+:N226010
     a skos:Concept ;
-    skos:broader :s226000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N226000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "226010" ;
     skos:prefLabel "Varusschlacht"@de .
 
-:s226020
+:N226020
     a skos:Concept ;
-    skos:broader :s226000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N226000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "226020" ;
     skos:prefLabel "Kelten"@de .
 
-:s226030
+:N226030
     a skos:Concept ;
-    skos:broader :s226000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N226000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "226030" ;
     skos:prefLabel "Römer"@de .
 
-:s226040
+:N226040
     a skos:Concept ;
-    skos:broader :s226000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N226000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "226040" ;
     skos:prefLabel "Germanen"@de .
 
-:s226050
+:N226050
     a skos:Concept ;
-    skos:broader :s226000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N226000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "226050" ;
     skos:prefLabel "Franken"@de .
 
-:s227000
+:N227000
     a skos:Concept ;
-    skos:broader :s220000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s227020, :s227030, :s227040 ;
+    skos:broader :N220000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N227020, :N227030, :N227040 ;
     skos:notation "227000" ;
     skos:prefLabel "Völkerwanderungszeit"@de .
 
-:s227020
+:N227020
     a skos:Concept ;
-    skos:broader :s227000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N227000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "227020" ;
     skos:prefLabel "Römer"@de .
 
-:s227030
+:N227030
     a skos:Concept ;
-    skos:broader :s227000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N227000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "227030" ;
     skos:prefLabel "Germanen"@de .
 
-:s227040
+:N227040
     a skos:Concept ;
-    skos:broader :s227000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N227000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "227040" ;
     skos:prefLabel "Franken"@de .
 
-:s228000
+:N228000
     a skos:Concept ;
-    skos:broader :s220000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N220000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "228000" ;
     skos:prefLabel "Mittelalter und Neuzeit"@de .
 
-:s240000
+:N240000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s2 ;
-    skos:narrower :s240100, :s240200, :s240500, :s240600, :s249800 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N2 ;
+    skos:narrower :N240100, :N240200, :N240500, :N240600, :N249800 ;
     skos:notation "240000" ;
     skos:prefLabel "Geschichte"@de .
 
-:s240100
+:N240100
     a skos:Concept ;
-    skos:broader :s240000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N240000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "240100" ;
     skos:prefLabel "Quellen"@de .
 
-:s240200
+:N240200
     a skos:Concept ;
-    skos:broader :s240000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N240000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "240200" ;
     skos:prefLabel "Geschichtsschreibung"@de .
 
-:s240500
+:N240500
     a skos:Concept ;
-    skos:broader :s240000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N240000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "240500" ;
     skos:prefLabel "Historische Ausstellungen"@de .
 
-:s240600
+:N240600
     a skos:Concept ;
-    skos:broader :s240000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N240000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "240600" ;
     skos:prefLabel "Gedenkstätten"@de .
 
-:s249800
+:N249800
     a skos:Concept ;
-    skos:broader :s240000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N240000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "249800" ;
     skos:prefLabel "Nordrhein-Westfalen, insgesamt"@de .
 
-:s260000
+:N260000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s2 ;
-    skos:narrower :s260100, :s262000, :s263000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N2 ;
+    skos:narrower :N260100, :N262000, :N263000 ;
     skos:notation "260000" ;
     skos:prefLabel "Militär. Wehrwesen"@de .
 
-:s260100
+:N260100
     a skos:Concept ;
-    skos:broader :s260000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N260000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "260100" ;
     skos:prefLabel "Militär. Wehrwesen - Allgemeines"@de .
 
-:s262000
+:N262000
     a skos:Concept ;
-    skos:broader :s260000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s262010, :s262020 ;
+    skos:broader :N260000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N262010, :N262020 ;
     skos:notation "262000" ;
     skos:prefLabel "Militär"@de .
 
-:s262010
+:N262010
     a skos:Concept ;
-    skos:broader :s262000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s262011, :s262012, :s262014, :s262016 ;
+    skos:broader :N262000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N262011, :N262012, :N262014, :N262016 ;
     skos:notation "262010" ;
     skos:prefLabel "Militärische Anlagen"@de .
 
-:s262011
+:N262011
     a skos:Concept ;
-    skos:broader :s262010 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N262010 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "262011" ;
     skos:prefLabel "Burgen"@de .
 
-:s262012
+:N262012
     a skos:Concept ;
-    skos:broader :s262010 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N262010 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "262012" ;
     skos:prefLabel "Festungen"@de .
 
-:s262014
+:N262014
     a skos:Concept ;
-    skos:broader :s262010 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N262010 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "262014" ;
     skos:prefLabel "Schanzen"@de .
 
-:s262016
+:N262016
     a skos:Concept ;
-    skos:broader :s262010 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N262010 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "262016" ;
     skos:prefLabel "Garnisonen"@de .
 
-:s262020
+:N262020
     a skos:Concept ;
-    skos:broader :s262000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s262022, :s262023, :s262024, :s262026 ;
+    skos:broader :N262000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N262022, :N262023, :N262024, :N262026 ;
     skos:notation "262020" ;
     skos:prefLabel "Militärische Ausrüstung"@de .
 
-:s262022
+:N262022
     a skos:Concept ;
-    skos:broader :s262020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N262020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "262022" ;
     skos:prefLabel "Waffen"@de .
 
-:s262023
+:N262023
     a skos:Concept ;
-    skos:broader :s262020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N262020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "262023" ;
     skos:prefLabel "Rüstungen"@de .
 
-:s262024
+:N262024
     a skos:Concept ;
-    skos:broader :s262020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N262020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "262024" ;
     skos:prefLabel "Uniformen"@de .
 
-:s262026
+:N262026
     a skos:Concept ;
-    skos:broader :s262020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N262020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "262026" ;
     skos:prefLabel "Militärische Auszeichnungen"@de .
 
-:s263000
+:N263000
     a skos:Concept ;
-    skos:broader :s260000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s263010, :s263020, :s263030, :s263040, :s263050, :s263060, :s263090 ;
+    skos:broader :N260000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N263010, :N263020, :N263030, :N263040, :N263050, :N263060, :N263090 ;
     skos:notation "263000" ;
     skos:prefLabel "Wehrwesen"@de .
 
-:s263010
+:N263010
     a skos:Concept ;
-    skos:broader :s263000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N263000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "263010" ;
     skos:prefLabel "Bürgerwehren"@de .
 
-:s263020
+:N263020
     a skos:Concept ;
-    skos:broader :s263000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N263000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "263020" ;
     skos:prefLabel "Militärgeschichte"@de .
 
-:s263030
+:N263030
     a skos:Concept ;
-    skos:broader :s263000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N263000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "263030" ;
     skos:prefLabel "Reichswehr"@de .
 
-:s263040
+:N263040
     a skos:Concept ;
-    skos:broader :s263000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N263000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "263040" ;
     skos:prefLabel "Wehrmacht"@de .
 
-:s263050
+:N263050
     a skos:Concept ;
-    skos:broader :s263000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N263000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "263050" ;
     skos:prefLabel "Besatzungstruppen. Ausländische Streitkräfte"@de .
 
-:s263060
+:N263060
     a skos:Concept ;
-    skos:broader :s263000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N263000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "263060" ;
     skos:prefLabel "Bundeswehr"@de .
 
-:s263090
+:N263090
     a skos:Concept ;
-    skos:broader :s263000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N263000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "263090" ;
     skos:prefLabel "Soldaten"@de .
 
-:s400000
+:N400000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s4 ;
-    skos:narrower :s400100, :s402000, :s402300, :s404000, :s404300, :s406000, :s406100, :s406200, :s406300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N4 ;
+    skos:narrower :N400100, :N402000, :N402300, :N404000, :N404300, :N406000, :N406100, :N406200, :N406300 ;
     skos:notation "400000" ;
     skos:prefLabel "Staat. Politik"@de .
 
-:s400100
+:N400100
     a skos:Concept ;
-    skos:broader :s400000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N400000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "400100" ;
     skos:prefLabel "Staat. Politik - Allgemeines"@de .
 
-:s402000
+:N402000
     a skos:Concept ;
-    skos:broader :s400000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s402020, :s402040, :s402060, :s402070 ;
+    skos:broader :N400000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N402020, :N402040, :N402060, :N402070 ;
     skos:notation "402000" ;
     skos:prefLabel "Staatsgrundlagen"@de .
 
-:s402020
+:N402020
     a skos:Concept ;
-    skos:broader :s402000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N402000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "402020" ;
     skos:prefLabel "Staatsrecht"@de .
 
-:s402040
+:N402040
     a skos:Concept ;
-    skos:broader :s402000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s402042 ;
+    skos:broader :N402000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N402042 ;
     skos:notation "402040" ;
     skos:prefLabel "Staatsgebiet"@de .
 
-:s402042
+:N402042
     a skos:Concept ;
-    skos:broader :s402040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N402040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "402042" ;
     skos:prefLabel "Grenzen"@de .
 
-:s402060
+:N402060
     a skos:Concept ;
-    skos:broader :s402000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N402000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "402060" ;
     skos:prefLabel "Staatsformen"@de .
 
-:s402070
+:N402070
     a skos:Concept ;
-    skos:broader :s402000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N402000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "402070" ;
     skos:prefLabel "Föderalismus"@de .
 
-:s402300
+:N402300
     a skos:Concept ;
-    skos:broader :s400000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s402330, :s402340 ;
+    skos:broader :N400000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N402330, :N402340 ;
     skos:notation "402300" ;
     skos:prefLabel "Verfassung"@de .
 
-:s402330
+:N402330
     a skos:Concept ;
-    skos:broader :s402300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N402300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "402330" ;
     skos:prefLabel "Verfassungsgeschichte"@de .
 
-:s402340
+:N402340
     a skos:Concept ;
-    skos:broader :s402300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N402300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "402340" ;
     skos:prefLabel "Grundrechte"@de .
 
-:s404000
+:N404000
     a skos:Concept ;
-    skos:broader :s400000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s404030, :s404040, :s404060, :s404070 ;
+    skos:broader :N400000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N404030, :N404040, :N404060, :N404070 ;
     skos:notation "404000" ;
     skos:prefLabel "Politisches System"@de .
 
-:s404030
+:N404030
     a skos:Concept ;
-    skos:broader :s404000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N404000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "404030" ;
     skos:prefLabel "Regierung"@de .
 
-:s404040
+:N404040
     a skos:Concept ;
-    skos:broader :s404000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N404000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "404040" ;
     skos:prefLabel "Ministerpräsident"@de .
 
-:s404060
+:N404060
     a skos:Concept ;
-    skos:broader :s404000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N404000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "404060" ;
     skos:prefLabel "Ministerien"@de .
 
-:s404070
+:N404070
     a skos:Concept ;
-    skos:broader :s404000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N404000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "404070" ;
     skos:prefLabel "Regierungspolitik"@de .
 
-:s404300
+:N404300
     a skos:Concept ;
-    skos:broader :s400000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s404320, :s404340, :s404350, :s404360, :s404380 ;
+    skos:broader :N400000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N404320, :N404340, :N404350, :N404360, :N404380 ;
     skos:notation "404300" ;
     skos:prefLabel "Parlament"@de .
 
-:s404320
+:N404320
     a skos:Concept ;
-    skos:broader :s404300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N404300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "404320" ;
     skos:prefLabel "Parlamentsgeschichte"@de .
 
-:s404340
+:N404340
     a skos:Concept ;
-    skos:broader :s404300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N404300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "404340" ;
     skos:prefLabel "Regierungsparteien"@de .
 
-:s404350
+:N404350
     a skos:Concept ;
-    skos:broader :s404300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N404300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "404350" ;
     skos:prefLabel "Opposition"@de .
 
-:s404360
+:N404360
     a skos:Concept ;
-    skos:broader :s404300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N404300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "404360" ;
     skos:prefLabel "Parlamentsausschüsse"@de .
 
-:s404380
+:N404380
     a skos:Concept ;
-    skos:broader :s404300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N404300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "404380" ;
     skos:prefLabel "Abgeordnete"@de .
 
-:s406000
+:N406000
     a skos:Concept ;
-    skos:broader :s400000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s406020, :s406030, :s406040, :s406060, :s406080 ;
+    skos:broader :N400000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N406020, :N406030, :N406040, :N406060, :N406080 ;
     skos:notation "406000" ;
     skos:prefLabel "Politische Willensbildung"@de .
 
-:s406020
+:N406020
     a skos:Concept ;
-    skos:broader :s406000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406020" ;
     skos:prefLabel "Öffentlichkeitsarbeit"@de .
 
-:s406030
+:N406030
     a skos:Concept ;
-    skos:broader :s406000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406030" ;
     skos:prefLabel "Politische Bildung"@de .
 
-:s406040
+:N406040
     a skos:Concept ;
-    skos:broader :s406000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406040" ;
     skos:prefLabel "Öffentliche Meinung"@de .
 
-:s406060
+:N406060
     a skos:Concept ;
-    skos:broader :s406000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406060" ;
     skos:prefLabel "Politische Bewegungen"@de .
 
-:s406080
+:N406080
     a skos:Concept ;
-    skos:broader :s406000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406080" ;
     skos:prefLabel "Politische Stiftungen"@de .
 
-:s406100
+:N406100
     a skos:Concept ;
-    skos:broader :s400000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s406120, :s406130 ;
+    skos:broader :N400000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N406120, :N406130 ;
     skos:notation "406100" ;
     skos:prefLabel "Parteien. Politiker"@de .
 
-:s406120
+:N406120
     a skos:Concept ;
-    skos:broader :s406100 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406100 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406120" ;
     skos:prefLabel "Parteien"@de .
 
-:s406130
+:N406130
     a skos:Concept ;
-    skos:broader :s406100 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406100 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406130" ;
     skos:prefLabel "Politiker"@de .
 
-:s406200
+:N406200
     a skos:Concept ;
-    skos:broader :s400000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s406230, :s406250, :s406270 ;
+    skos:broader :N400000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N406230, :N406250, :N406270 ;
     skos:notation "406200" ;
     skos:prefLabel "Politische Gruppen"@de .
 
-:s406230
+:N406230
     a skos:Concept ;
-    skos:broader :s406200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406230" ;
     skos:prefLabel "Interessenverbände"@de .
 
-:s406250
+:N406250
     a skos:Concept ;
-    skos:broader :s406200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406250" ;
     skos:prefLabel "Bürgerinitiativen"@de .
 
-:s406270
+:N406270
     a skos:Concept ;
-    skos:broader :s406200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406270" ;
     skos:prefLabel "Protestbewegungen"@de .
 
-:s406300
+:N406300
     a skos:Concept ;
-    skos:broader :s400000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s406310, :s406330, :s406340, :s406350, :s406360, :s406370, :s406380 ;
+    skos:broader :N400000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N406310, :N406330, :N406340, :N406350, :N406360, :N406370, :N406380 ;
     skos:notation "406300" ;
     skos:prefLabel "Wahlen"@de .
 
-:s406310
+:N406310
     a skos:Concept ;
-    skos:broader :s406300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406310" ;
     skos:prefLabel "Wahlrecht"@de .
 
-:s406330
+:N406330
     a skos:Concept ;
-    skos:broader :s406300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406330" ;
     skos:prefLabel "Volksabstimmungen"@de .
 
-:s406340
+:N406340
     a skos:Concept ;
-    skos:broader :s406300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406340" ;
     skos:prefLabel "Europawahlen"@de .
 
-:s406350
+:N406350
     a skos:Concept ;
-    skos:broader :s406300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406350" ;
     skos:prefLabel "Bundestagswahlen"@de .
 
-:s406360
+:N406360
     a skos:Concept ;
-    skos:broader :s406300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406360" ;
     skos:prefLabel "Landtagswahlen"@de .
 
-:s406370
+:N406370
     a skos:Concept ;
-    skos:broader :s406300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406370" ;
     skos:prefLabel "Kreistagswahlen"@de .
 
-:s406380
+:N406380
     a skos:Concept ;
-    skos:broader :s406300 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N406300 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "406380" ;
     skos:prefLabel "Kommunalwahlen"@de .
 
-:s420000
+:N420000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s4 ;
-    skos:narrower :s420100, :s421000, :s421400, :s422000, :s423000, :s423400, :s423600, :s424000, :s425000, :s425200, :s425400, :s426000, :s428000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N4 ;
+    skos:narrower :N420100, :N421000, :N421400, :N422000, :N423000, :N423400, :N423600, :N424000, :N425000, :N425200, :N425400, :N426000, :N428000 ;
     skos:notation "420000" ;
     skos:prefLabel "Verwaltung"@de .
 
-:s420100
+:N420100
     a skos:Concept ;
-    skos:broader :s420000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N420000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "420100" ;
     skos:prefLabel "Verwaltung - Allgemeines"@de .
 
-:s421000
+:N421000
     a skos:Concept ;
-    skos:broader :s420000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N420000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "421000" ;
     skos:prefLabel "Verwaltungsrecht"@de .
 
-:s421400
+:N421400
     a skos:Concept ;
-    skos:broader :s420000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N420000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "421400" ;
     skos:prefLabel "Verwaltungskontrolle"@de .
 
-:s422000
+:N422000
     a skos:Concept ;
-    skos:broader :s420000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N420000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "422000" ;
     skos:prefLabel "Verwaltungsgeschichte"@de .
 
-:s423000
+:N423000
     a skos:Concept ;
-    skos:broader :s420000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s423030, :s423050 ;
+    skos:broader :N420000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N423030, :N423050 ;
     skos:notation "423000" ;
     skos:prefLabel "Allgemeine Verwaltung"@de .
 
-:s423030
+:N423030
     a skos:Concept ;
-    skos:broader :s423000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N423000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "423030" ;
     skos:prefLabel "Organisation"@de .
 
-:s423050
+:N423050
     a skos:Concept ;
-    skos:broader :s423000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N423000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "423050" ;
     skos:prefLabel "Datenverarbeitung"@de .
 
-:s423400
+:N423400
     a skos:Concept ;
-    skos:broader :s420000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s423420, :s423430, :s423440 ;
+    skos:broader :N420000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N423420, :N423430, :N423440 ;
     skos:notation "423400" ;
     skos:prefLabel "Verwaltungsreform"@de .
 
-:s423420
+:N423420
     a skos:Concept ;
-    skos:broader :s423400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N423400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "423420" ;
     skos:prefLabel "Länderneugliederung"@de .
 
-:s423430
+:N423430
     a skos:Concept ;
-    skos:broader :s423400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N423400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "423430" ;
     skos:prefLabel "Gebietsreform"@de .
 
-:s423440
+:N423440
     a skos:Concept ;
-    skos:broader :s423400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N423400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "423440" ;
     skos:prefLabel "Funktionalreform"@de .
 
-:s423600
+:N423600
     a skos:Concept ;
-    skos:broader :s420000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s423610, :s423620, :s423640 ;
+    skos:broader :N420000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N423610, :N423620, :N423640 ;
     skos:notation "423600" ;
     skos:prefLabel "Öffentlicher Dienst"@de .
 
-:s423610
+:N423610
     a skos:Concept ;
-    skos:broader :s423600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N423600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "423610" ;
     skos:prefLabel "Dienstrecht"@de .
 
-:s423620
+:N423620
     a skos:Concept ;
-    skos:broader :s423600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N423600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "423620" ;
     skos:prefLabel "Personalwesen"@de .
 
-:s423640
+:N423640
     a skos:Concept ;
-    skos:broader :s423600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N423600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "423640" ;
     skos:prefLabel "Beamte"@de .
 
-:s424000
+:N424000
     a skos:Concept ;
-    skos:broader :s420000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s424020, :s424030, :s424040, :s424050, :s424060 ;
+    skos:broader :N420000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N424020, :N424030, :N424040, :N424050, :N424060 ;
     skos:notation "424000" ;
     skos:prefLabel "Öffentlicher Haushalt"@de .
 
-:s424020
+:N424020
     a skos:Concept ;
-    skos:broader :s424000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s424021, :s424022, :s424024, :s424026, :s424028 ;
+    skos:broader :N424000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N424021, :N424022, :N424024, :N424026, :N424028 ;
     skos:notation "424020" ;
     skos:prefLabel "Finanzverwaltung"@de .
 
-:s424021
+:N424021
     a skos:Concept ;
-    skos:broader :s424020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N424020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "424021" ;
     skos:prefLabel "Finanzämter"@de .
 
-:s424022
+:N424022
     a skos:Concept ;
-    skos:broader :s424020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N424020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "424022" ;
     skos:prefLabel "Finanzausgleich"@de .
 
-:s424024
+:N424024
     a skos:Concept ;
-    skos:broader :s424020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N424020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "424024" ;
     skos:prefLabel "Finanzreform"@de .
 
-:s424026
+:N424026
     a skos:Concept ;
-    skos:broader :s424020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N424020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "424026" ;
     skos:prefLabel "Vergabe"@de .
 
-:s424028
+:N424028
     a skos:Concept ;
-    skos:broader :s424020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N424020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "424028" ;
     skos:prefLabel "Rechnungshof"@de .
 
-:s424030
+:N424030
     a skos:Concept ;
-    skos:broader :s424000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N424000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "424030" ;
     skos:prefLabel "Abgaben"@de .
 
-:s424040
+:N424040
     a skos:Concept ;
-    skos:broader :s424000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s424042 ;
+    skos:broader :N424000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N424042 ;
     skos:notation "424040" ;
     skos:prefLabel "Steuern"@de .
 
-:s424042
+:N424042
     a skos:Concept ;
-    skos:broader :s424040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N424040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "424042" ;
     skos:prefLabel "Steuerberatung"@de .
 
-:s424050
+:N424050
     a skos:Concept ;
-    skos:broader :s424000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N424000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "424050" ;
     skos:prefLabel "Gebühren"@de .
 
-:s424060
+:N424060
     a skos:Concept ;
-    skos:broader :s424000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N424000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "424060" ;
     skos:prefLabel "Zölle"@de .
 
-:s425000
+:N425000
     a skos:Concept ;
-    skos:broader :s420000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s425020, :s425030, :s425040, :s425050 ;
+    skos:broader :N420000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N425020, :N425030, :N425040, :N425050 ;
     skos:notation "425000" ;
     skos:prefLabel "Provinzialverwaltung"@de .
 
-:s425020
+:N425020
     a skos:Concept ;
-    skos:broader :s425000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N425000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "425020" ;
     skos:prefLabel "Landschaftsverband Rheinland"@de .
 
-:s425030
+:N425030
     a skos:Concept ;
-    skos:broader :s425000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N425000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "425030" ;
     skos:prefLabel "Landschaftsverband Westfalen-Lippe"@de .
 
-:s425040
+:N425040
     a skos:Concept ;
-    skos:broader :s425000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N425000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "425040" ;
     skos:prefLabel "Landesverband Lippe"@de .
 
-:s425050
+:N425050
     a skos:Concept ;
-    skos:broader :s425000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N425000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "425050" ;
     skos:prefLabel "Kommunalverband Ruhrgebiet"@de .
 
-:s425200
+:N425200
     a skos:Concept ;
-    skos:broader :s420000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N420000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "425200" ;
     skos:prefLabel "Regierungsbezirke"@de .
 
-:s425400
+:N425400
     a skos:Concept ;
-    skos:broader :s420000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s425420, :s425430, :s425490 ;
+    skos:broader :N420000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N425420, :N425430, :N425490 ;
     skos:notation "425400" ;
     skos:prefLabel "Kreisverwaltung"@de .
 
-:s425420
+:N425420
     a skos:Concept ;
-    skos:broader :s425400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N425400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "425420" ;
     skos:prefLabel "Kreisrecht"@de .
 
-:s425430
+:N425430
     a skos:Concept ;
-    skos:broader :s425400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N425400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "425430" ;
     skos:prefLabel "Kreistage"@de .
 
-:s425490
+:N425490
     a skos:Concept ;
-    skos:broader :s425400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N425400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "425490" ;
     skos:prefLabel "Kreispartnerschaften"@de .
 
-:s426000
+:N426000
     a skos:Concept ;
-    skos:broader :s420000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s426020, :s426030, :s426040, :s426050, :s426060, :s426070, :s426090 ;
+    skos:broader :N420000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N426020, :N426030, :N426040, :N426050, :N426060, :N426070, :N426090 ;
     skos:notation "426000" ;
     skos:prefLabel "Gemeindeverwaltung"@de .
 
-:s426020
+:N426020
     a skos:Concept ;
-    skos:broader :s426000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N426000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "426020" ;
     skos:prefLabel "Kommunalrecht"@de .
 
-:s426030
+:N426030
     a skos:Concept ;
-    skos:broader :s426000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N426000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "426030" ;
     skos:prefLabel "Gemeinderat"@de .
 
-:s426040
+:N426040
     a skos:Concept ;
-    skos:broader :s426000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N426000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "426040" ;
     skos:prefLabel "Kommunale Selbstverwaltung"@de .
 
-:s426050
+:N426050
     a skos:Concept ;
-    skos:broader :s426000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N426000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "426050" ;
     skos:prefLabel "Auftragsverwaltung"@de .
 
-:s426060
+:N426060
     a skos:Concept ;
-    skos:broader :s426000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N426000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "426060" ;
     skos:prefLabel "Kommunale Spitzenverbände"@de .
 
-:s426070
+:N426070
     a skos:Concept ;
-    skos:broader :s426000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N426000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "426070" ;
     skos:prefLabel "Gemeindeverbände"@de .
 
-:s426090
+:N426090
     a skos:Concept ;
-    skos:broader :s426000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N426000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "426090" ;
     skos:prefLabel "Städtepartnerschaften"@de .
 
-:s428000
+:N428000
     a skos:Concept ;
-    skos:broader :s420000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s428020, :s428030, :s428040, :s428050, :s428060, :s428070 ;
+    skos:broader :N420000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N428020, :N428030, :N428040, :N428050, :N428060, :N428070 ;
     skos:notation "428000" ;
     skos:prefLabel "Sicherheit und Ordnung"@de .
 
-:s428020
+:N428020
     a skos:Concept ;
-    skos:broader :s428000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N428000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "428020" ;
     skos:prefLabel "Ordnungsrecht"@de .
 
-:s428030
+:N428030
     a skos:Concept ;
-    skos:broader :s428000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s428032 ;
+    skos:broader :N428000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N428032 ;
     skos:notation "428030" ;
     skos:prefLabel "Polizei"@de .
 
-:s428032
+:N428032
     a skos:Concept ;
-    skos:broader :s428030 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N428030 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "428032" ;
     skos:prefLabel "Polizeiorganisation"@de .
 
-:s428040
+:N428040
     a skos:Concept ;
-    skos:broader :s428000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N428000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "428040" ;
     skos:prefLabel "Zivilschutz"@de .
 
-:s428050
+:N428050
     a skos:Concept ;
-    skos:broader :s428000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s428052, :s428054 ;
+    skos:broader :N428000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N428052, :N428054 ;
     skos:notation "428050" ;
     skos:prefLabel "Staatsschutz"@de .
 
-:s428052
+:N428052
     a skos:Concept ;
-    skos:broader :s428050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N428050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "428052" ;
     skos:prefLabel "Grenzschutz"@de .
 
-:s428054
+:N428054
     a skos:Concept ;
-    skos:broader :s428050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N428050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "428054" ;
     skos:prefLabel "Verfassungsschutz"@de .
 
-:s428060
+:N428060
     a skos:Concept ;
-    skos:broader :s428000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N428000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "428060" ;
     skos:prefLabel "Personenstand"@de .
 
-:s428070
+:N428070
     a skos:Concept ;
-    skos:broader :s428000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s428072, :s428074, :s428076, :s428078 ;
+    skos:broader :N428000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N428072, :N428074, :N428076, :N428078 ;
     skos:notation "428070" ;
     skos:prefLabel "Sicherheitsverwaltung"@de .
 
-:s428072
+:N428072
     a skos:Concept ;
-    skos:broader :s428070 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N428070 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "428072" ;
     skos:prefLabel "Technische Überwachungsvereine"@de .
 
-:s428074
+:N428074
     a skos:Concept ;
-    skos:broader :s428070 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N428070 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "428074" ;
     skos:prefLabel "Brandbekämpfung"@de .
 
-:s428076
+:N428076
     a skos:Concept ;
-    skos:broader :s428070 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N428070 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "428076" ;
     skos:prefLabel "Rettungswesen"@de .
 
-:s428078
+:N428078
     a skos:Concept ;
-    skos:broader :s428070 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N428070 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "428078" ;
     skos:prefLabel "Katastrophen. Unfälle"@de .
 
-:s440000
+:N440000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s4 ;
-    skos:narrower :s440100, :s442000, :s443000, :s444000, :s446000, :s447000, :s448000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N4 ;
+    skos:narrower :N440100, :N442000, :N443000, :N444000, :N446000, :N447000, :N448000 ;
     skos:notation "440000" ;
     skos:prefLabel "Recht"@de .
 
-:s440100
+:N440100
     a skos:Concept ;
-    skos:broader :s440000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N440000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "440100" ;
     skos:prefLabel "Recht - Allgemeines"@de .
 
-:s442000
+:N442000
     a skos:Concept ;
-    skos:broader :s440000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s442050 ;
+    skos:broader :N440000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N442050 ;
     skos:notation "442000" ;
     skos:prefLabel "Rechtsgeschichte"@de .
 
-:s442050
+:N442050
     a skos:Concept ;
-    skos:broader :s442000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N442000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "442050" ;
     skos:prefLabel "Rechtsgeschichtliche Quellen"@de .
 
-:s443000
+:N443000
     a skos:Concept ;
-    skos:broader :s440000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N440000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "443000" ;
     skos:prefLabel "Privatrecht"@de .
 
-:s444000
+:N444000
     a skos:Concept ;
-    skos:broader :s440000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s444030, :s444050, :s444070 ;
+    skos:broader :N440000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N444030, :N444050, :N444070 ;
     skos:notation "444000" ;
     skos:prefLabel "Strafrecht"@de .
 
-:s444030
+:N444030
     a skos:Concept ;
-    skos:broader :s444000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N444000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "444030" ;
     skos:prefLabel "Strafvollzug"@de .
 
-:s444050
+:N444050
     a skos:Concept ;
-    skos:broader :s444000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N444000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "444050" ;
     skos:prefLabel "Kriminalität"@de .
 
-:s444070
+:N444070
     a skos:Concept ;
-    skos:broader :s444000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N444000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "444070" ;
     skos:prefLabel "Kriminalgeschichte"@de .
 
-:s446000
+:N446000
     a skos:Concept ;
-    skos:broader :s440000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s446010, :s446030, :s446050, :s446060, :s446070, :s446080 ;
+    skos:broader :N440000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N446010, :N446030, :N446050, :N446060, :N446070, :N446080 ;
     skos:notation "446000" ;
     skos:prefLabel "Gerichtsbarkeit"@de .
 
-:s446010
+:N446010
     a skos:Concept ;
-    skos:broader :s446000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N446000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "446010" ;
     skos:prefLabel "Verfassungsgerichtsbarkeit"@de .
 
-:s446030
+:N446030
     a skos:Concept ;
-    skos:broader :s446000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s446032, :s446034 ;
+    skos:broader :N446000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N446032, :N446034 ;
     skos:notation "446030" ;
     skos:prefLabel "Ordentliche Gerichtsbarkeit"@de .
 
-:s446032
+:N446032
     a skos:Concept ;
-    skos:broader :s446030 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N446030 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "446032" ;
     skos:prefLabel "Strafgerichtsbarkeit"@de .
 
-:s446034
+:N446034
     a skos:Concept ;
-    skos:broader :s446030 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N446030 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "446034" ;
     skos:prefLabel "Zivilgerichtsbarkeit"@de .
 
-:s446050
+:N446050
     a skos:Concept ;
-    skos:broader :s446000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N446000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "446050" ;
     skos:prefLabel "Verwaltungsgerichtsbarkeit"@de .
 
-:s446060
+:N446060
     a skos:Concept ;
-    skos:broader :s446000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N446000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "446060" ;
     skos:prefLabel "Finanzgerichtsbarkeit"@de .
 
-:s446070
+:N446070
     a skos:Concept ;
-    skos:broader :s446000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N446000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "446070" ;
     skos:prefLabel "Arbeitsgerichtsbarkeit"@de .
 
-:s446080
+:N446080
     a skos:Concept ;
-    skos:broader :s446000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N446000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "446080" ;
     skos:prefLabel "Sozialgerichtsbarkeit"@de .
 
-:s447000
+:N447000
     a skos:Concept ;
-    skos:broader :s440000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N440000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "447000" ;
     skos:prefLabel "Rechtsprechung"@de .
 
-:s448000
+:N448000
     a skos:Concept ;
-    skos:broader :s440000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N440000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "448000" ;
     skos:prefLabel "Rechtspflege"@de .
 
-:s500000
+:N500000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s5 ;
-    skos:narrower :s500100, :s502000, :s503000, :s503200, :s503400, :s503600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N5 ;
+    skos:narrower :N500100, :N502000, :N503000, :N503200, :N503400, :N503600 ;
     skos:notation "500000" ;
     skos:prefLabel "Bevölkerung"@de .
 
-:s500100
+:N500100
     a skos:Concept ;
-    skos:broader :s500000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N500000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "500100" ;
     skos:prefLabel "Bevölkerung - Allgemeines"@de .
 
-:s502000
+:N502000
     a skos:Concept ;
-    skos:broader :s500000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N500000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "502000" ;
     skos:prefLabel "Bevölkerungsgeschichte"@de .
 
-:s503000
+:N503000
     a skos:Concept ;
-    skos:broader :s500000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s503020, :s503030, :s503040, :s503050, :s503060, :s503070, :s503080, :s503090 ;
+    skos:broader :N500000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N503020, :N503030, :N503040, :N503050, :N503060, :N503070, :N503080, :N503090 ;
     skos:notation "503000" ;
     skos:prefLabel "Bevölkerungsstruktur"@de .
 
-:s503020
+:N503020
     a skos:Concept ;
-    skos:broader :s503000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503020" ;
     skos:prefLabel "Altersstruktur"@de .
 
-:s503030
+:N503030
     a skos:Concept ;
-    skos:broader :s503000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503030" ;
     skos:prefLabel "Geschlechtsverhältnis"@de .
 
-:s503040
+:N503040
     a skos:Concept ;
-    skos:broader :s503000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503040" ;
     skos:prefLabel "Volkszählung"@de .
 
-:s503050
+:N503050
     a skos:Concept ;
-    skos:broader :s503000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503050" ;
     skos:prefLabel "Einwohnerverzeichnisse"@de .
 
-:s503060
+:N503060
     a skos:Concept ;
-    skos:broader :s503000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503060" ;
     skos:prefLabel "Haushalte"@de .
 
-:s503070
+:N503070
     a skos:Concept ;
-    skos:broader :s503000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503070" ;
     skos:prefLabel "Wohnen"@de .
 
-:s503080
+:N503080
     a skos:Concept ;
-    skos:broader :s503000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503080" ;
     skos:prefLabel "Einkommen. Vermögen"@de .
 
-:s503090
+:N503090
     a skos:Concept ;
-    skos:broader :s503000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503090" ;
     skos:prefLabel "Religionen"@de .
 
-:s503200
+:N503200
     a skos:Concept ;
-    skos:broader :s500000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s503220, :s503230, :s503240, :s503250, :s503260 ;
+    skos:broader :N500000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N503220, :N503230, :N503240, :N503250, :N503260 ;
     skos:notation "503200" ;
     skos:prefLabel "Bevölkerungsentwicklung"@de .
 
-:s503220
+:N503220
     a skos:Concept ;
-    skos:broader :s503200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503220" ;
     skos:prefLabel "Bevölkerungspolitik"@de .
 
-:s503230
+:N503230
     a skos:Concept ;
-    skos:broader :s503200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503230" ;
     skos:prefLabel "Geburtenziffer"@de .
 
-:s503240
+:N503240
     a skos:Concept ;
-    skos:broader :s503200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503240" ;
     skos:prefLabel "Eheschließungen"@de .
 
-:s503250
+:N503250
     a skos:Concept ;
-    skos:broader :s503200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503250" ;
     skos:prefLabel "Sterbeziffer"@de .
 
-:s503260
+:N503260
     a skos:Concept ;
-    skos:broader :s503200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503260" ;
     skos:prefLabel "Prognosen"@de .
 
-:s503400
+:N503400
     a skos:Concept ;
-    skos:broader :s500000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s503420, :s503430, :s503440 ;
+    skos:broader :N500000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N503420, :N503430, :N503440 ;
     skos:notation "503400" ;
     skos:prefLabel "Migration"@de .
 
-:s503420
+:N503420
     a skos:Concept ;
-    skos:broader :s503400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s503424 ;
+    skos:broader :N503400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N503424 ;
     skos:notation "503420" ;
     skos:prefLabel "Binnenwanderung"@de .
 
-:s503424
+:N503424
     a skos:Concept ;
-    skos:broader :s503420 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503420 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503424" ;
     skos:prefLabel "Pendler"@de .
 
-:s503430
+:N503430
     a skos:Concept ;
-    skos:broader :s503400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503430" ;
     skos:prefLabel "Auswanderung"@de .
 
-:s503440
+:N503440
     a skos:Concept ;
-    skos:broader :s503400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N503400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503440" ;
     skos:prefLabel "Einwanderung"@de .
 
-:s503600
+:N503600
     a skos:Concept ;
-    skos:broader :s500000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N500000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "503600" ;
     skos:prefLabel "Bevölkerungsdichte"@de .
 
-:s520000
+:N520000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s5 ;
-    skos:narrower :s520100, :s521000, :s521200, :s521400, :s522000, :s523000, :s52400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N5 ;
+    skos:narrower :N520100, :N521000, :N521200, :N521400, :N522000, :N523000, :N52400 ;
     skos:notation "520000" ;
     skos:prefLabel "Sozialwesen"@de .
 
-:s520100
+:N520100
     a skos:Concept ;
-    skos:broader :s520000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N520000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "520100" ;
     skos:prefLabel "Sozialwesen - Allgemeines"@de .
 
-:s521000
+:N521000
     a skos:Concept ;
-    skos:broader :s520000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N520000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "521000" ;
     skos:prefLabel "Sozialpolitik"@de .
 
-:s521200
+:N521200
     a skos:Concept ;
-    skos:broader :s520000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N520000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "521200" ;
     skos:prefLabel "Sozialrecht"@de .
 
-:s521400
+:N521400
     a skos:Concept ;
-    skos:broader :s520000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s521410, :s521420, :s521440, :s521450 ;
+    skos:broader :N520000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N521410, :N521420, :N521440, :N521450 ;
     skos:notation "521400" ;
     skos:prefLabel "Sozialversicherung"@de .
 
-:s521410
+:N521410
     a skos:Concept ;
-    skos:broader :s521400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N521400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "521410" ;
     skos:prefLabel "Krankenversicherung"@de .
 
-:s521420
+:N521420
     a skos:Concept ;
-    skos:broader :s521400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N521400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "521420" ;
     skos:prefLabel "Unfallversicherung"@de .
 
-:s521440
+:N521440
     a skos:Concept ;
-    skos:broader :s521400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N521400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "521440" ;
     skos:prefLabel "Rentenversicherung"@de .
 
-:s521450
+:N521450
     a skos:Concept ;
-    skos:broader :s521400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N521400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "521450" ;
     skos:prefLabel "Arbeitslosenversicherung"@de .
 
-:s522000
+:N522000
     a skos:Concept ;
-    skos:broader :s520000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s522010, :s522020, :s522030 ;
+    skos:broader :N520000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N522010, :N522020, :N522030 ;
     skos:notation "522000" ;
     skos:prefLabel "Sozialhilfeträger"@de .
 
-:s522010
+:N522010
     a skos:Concept ;
-    skos:broader :s522000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N522000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "522010" ;
     skos:prefLabel "Öffentliche Träger"@de .
 
-:s522020
+:N522020
     a skos:Concept ;
-    skos:broader :s522000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N522000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "522020" ;
     skos:prefLabel "Kirchliche Träger"@de .
 
-:s522030
+:N522030
     a skos:Concept ;
-    skos:broader :s522000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N522000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "522030" ;
     skos:prefLabel "Private Träger"@de .
 
-:s523000
+:N523000
     a skos:Concept ;
-    skos:broader :s520000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s523001, :s523010, :s523020, :s523030, :s523040, :s523050, :s523060, :s523070, :s523080, :s523090 ;
+    skos:broader :N520000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N523001, :N523010, :N523020, :N523030, :N523040, :N523050, :N523060, :N523070, :N523080, :N523090 ;
     skos:notation "523000" ;
     skos:prefLabel "Sozialhilfe (Fürsorge)"@de .
 
-:s523001
+:N523001
     a skos:Concept ;
-    skos:broader :s523000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N523000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "523001" ;
     skos:prefLabel "Sozialarbeit"@de .
 
-:s523010
+:N523010
     a skos:Concept ;
-    skos:broader :s523000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N523000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "523010" ;
     skos:prefLabel "Arbeitslosenhilfe"@de .
 
-:s523020
+:N523020
     a skos:Concept ;
-    skos:broader :s523000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N523000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "523020" ;
     skos:prefLabel "Gefangenenfürsorge"@de .
 
-:s523030
+:N523030
     a skos:Concept ;
-    skos:broader :s523000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s523035 ;
+    skos:broader :N523000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N523035 ;
     skos:notation "523030" ;
     skos:prefLabel "Armenfürsorge"@de .
 
-:s523035
+:N523035
     a skos:Concept ;
-    skos:broader :s523030 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N523030 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "523035" ;
     skos:prefLabel "Obdachlosenhilfe"@de .
 
-:s523040
+:N523040
     a skos:Concept ;
-    skos:broader :s523000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N523000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "523040" ;
     skos:prefLabel "Unfallfürsorge"@de .
 
-:s523050
+:N523050
     a skos:Concept ;
-    skos:broader :s523000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N523000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "523050" ;
     skos:prefLabel "Krankenfürsorge"@de .
 
-:s523060
+:N523060
     a skos:Concept ;
-    skos:broader :s523000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N523000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "523060" ;
     skos:prefLabel "Behindertenhilfe"@de .
 
-:s523070
+:N523070
     a skos:Concept ;
-    skos:broader :s523000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N523000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "523070" ;
     skos:prefLabel "Kriegsopferfürsorge"@de .
 
-:s523080
+:N523080
     a skos:Concept ;
-    skos:broader :s523000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N523000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "523080" ;
     skos:prefLabel "Waisenfürsorge"@de .
 
-:s523090
+:N523090
     a skos:Concept ;
-    skos:broader :s523000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N523000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "523090" ;
     skos:prefLabel "Altenhilfe"@de .
 
-:s524000
+:N524000
     a skos:Concept ;
-    skos:broader :s520000 ; ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s524010, :s524030, :s524050, :s524060, :s524070 ;
+    skos:broader :N520000 ; ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N524010, :N524030, :N524050, :N524060, :N524070 ;
     skos:notation "524000" ;
     skos:prefLabel "Sozialpädagogik"@de .
 
-:s524010
+:N524010
     a skos:Concept ;
-    skos:broader :s524000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N524000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "524010" ;
     skos:prefLabel "Kinder- und Jugendhilfe"@de .
 
-:s524030
+:N524030
     a skos:Concept ;
-    skos:broader :s524000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N524000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "524030" ;
     skos:prefLabel "Fürsorgeerziehung"@de .
 
-:s524050
+:N524050
     a skos:Concept ;
-    skos:broader :s524000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N524000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "524050" ;
     skos:prefLabel "Bewährungshilfe"@de .
 
-:s524060
+:N524060
     a skos:Concept ;
-    skos:broader :s524000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N524000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "524060" ;
     skos:prefLabel "Erziehungsberatung"@de .
 
-:s524070
+:N524070
     a skos:Concept ;
-    skos:broader :s524000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N524000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "524070" ;
     skos:prefLabel "Familienfürsorge"@de .
 
-:s530000
+:N530000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s5 ;
-    skos:narrower :s530100, :s532000, :s533000, :s534000, :s535000, :s537000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N5 ;
+    skos:narrower :N530100, :N532000, :N533000, :N534000, :N535000, :N537000 ;
     skos:notation "530000" ;
     skos:prefLabel "Gesundheitswesen"@de .
 
-:s530100
+:N530100
     a skos:Concept ;
-    skos:broader :s530000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N530000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "530100" ;
     skos:prefLabel "Gesundheitswesen - Allgemeines"@de .
 
-:s532000
+:N532000
     a skos:Concept ;
-    skos:broader :s530000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s532010, :s532030, :s532050, :s532070 ;
+    skos:broader :N530000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N532010, :N532030, :N532050, :N532070 ;
     skos:notation "532000" ;
     skos:prefLabel "Medizin"@de .
 
-:s532010
+:N532010
     a skos:Concept ;
-    skos:broader :s532000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N532000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "532010" ;
     skos:prefLabel "Medizingeschichte"@de .
 
-:s532030
+:N532030
     a skos:Concept ;
-    skos:broader :s532000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N532000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "532030" ;
     skos:prefLabel "Medizinische Versorgung"@de .
 
-:s532050
+:N532050
     a skos:Concept ;
-    skos:broader :s532000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N532000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "532050" ;
     skos:prefLabel "Ärzte. Heilberufe"@de .
 
-:s532070
+:N532070
     a skos:Concept ;
-    skos:broader :s532000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N532000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "532070" ;
     skos:prefLabel "Gesundheitsvorsorge"@de .
 
-:s533000
+:N533000
     a skos:Concept ;
-    skos:broader :s530000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N530000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "533000" ;
     skos:prefLabel "Apotheken"@de .
 
-:s534000
+:N534000
     a skos:Concept ;
-    skos:broader :s530000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s534010, :s534020, :s534030, :s534050, :s534060, :s534080 ;
+    skos:broader :N530000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N534010, :N534020, :N534030, :N534050, :N534060, :N534080 ;
     skos:notation "534000" ;
     skos:prefLabel "Krankenversorgung"@de .
 
-:s534010
+:N534010
     a skos:Concept ;
-    skos:broader :s534000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N534000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "534010" ;
     skos:prefLabel "Krankenpflege"@de .
 
-:s534020
+:N534020
     a skos:Concept ;
-    skos:broader :s534000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N534000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "534020" ;
     skos:prefLabel "Pflegepersonal"@de .
 
-:s534030
+:N534030
     a skos:Concept ;
-    skos:broader :s534000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N534000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "534030" ;
     skos:prefLabel "Krankenhäuser"@de .
 
-:s534050
+:N534050
     a skos:Concept ;
-    skos:broader :s534000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N534000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "534050" ;
     skos:prefLabel "Kur- und Heilstätten"@de .
 
-:s534060
+:N534060
     a skos:Concept ;
-    skos:broader :s534000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N534000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "534060" ;
     skos:prefLabel "Suchtkrankenhilfe"@de .
 
-:s534080
+:N534080
     a skos:Concept ;
-    skos:broader :s534000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N534000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "534080" ;
     skos:prefLabel "Psychiatrie"@de .
 
-:s535000
+:N535000
     a skos:Concept ;
-    skos:broader :s530000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N530000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "535000" ;
     skos:prefLabel "Hygiene"@de .
 
-:s537000
+:N537000
     a skos:Concept ;
-    skos:broader :s530000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N530000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "537000" ;
     skos:prefLabel "Veterinärwesen"@de .
 
-:s540000
+:N540000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s5 ;
-    skos:narrower :s540100, :s541000, :s541500, :s542000, :s543000, :s543200, :s543400, :s543600, :s543800, :s544000, :s544200, :s544400, :s544600, :s545000, :s546000, :s547000, :s547400, :s547600, :s548000, :s548200, :s548300, :s548400, :s548500, :s548600, :s548800 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N5 ;
+    skos:narrower :N540100, :N541000, :N541500, :N542000, :N543000, :N543200, :N543400, :N543600, :N543800, :N544000, :N544200, :N544400, :N544600, :N545000, :N546000, :N547000, :N547400, :N547600, :N548000, :N548200, :N548300, :N548400, :N548500, :N548600, :N548800 ;
     skos:notation "540000" ;
     skos:prefLabel "Wirtschaft"@de .
 
-:s540100
+:N540100
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "540100" ;
     skos:prefLabel "Wirtschaft - Allgemeines"@de .
 
-:s541000
+:N541000
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "541000" ;
     skos:prefLabel "Wirtschaftspolitik"@de .
 
-:s541500
+:N541500
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "541500" ;
     skos:prefLabel "Wirtschaftsrecht"@de .
 
-:s542000
+:N542000
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "542000" ;
     skos:prefLabel "Wirtschaftsgeschichte"@de .
 
-:s543000
+:N543000
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s543010, :s543020, :s543060, :s543080 ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N543010, :N543020, :N543060, :N543080 ;
     skos:notation "543000" ;
     skos:prefLabel "Wirtschaftsstruktur"@de .
 
-:s543010
+:N543010
     a skos:Concept ;
-    skos:broader :s543000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543010" ;
     skos:prefLabel "Unternehmen"@de .
 
-:s543020
+:N543020
     a skos:Concept ;
-    skos:broader :s543000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543020" ;
     skos:prefLabel "Wirtschaftsförderung"@de .
 
-:s543060
+:N543060
     a skos:Concept ;
-    skos:broader :s543000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s543062 ;
+    skos:broader :N543000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N543062 ;
     skos:notation "543060" ;
     skos:prefLabel "Außenwirtschaft"@de .
 
-:s543062
+:N543062
     a skos:Concept ;
-    skos:broader :s543060 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543060 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543062" ;
     skos:prefLabel "Europäische Union"@de .
 
-:s543080
+:N543080
     a skos:Concept ;
-    skos:broader :s543000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543080" ;
     skos:prefLabel "Wirtschaftsstatistik"@de .
 
-:s543200
+:N543200
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543200" ;
     skos:prefLabel "Wirtschaftsverfassung"@de .
 
-:s543400
+:N543400
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s543420, :s543430, :s543440, :s543460, :s543480 ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N543420, :N543430, :N543440, :N543460, :N543480 ;
     skos:notation "543400" ;
     skos:prefLabel "Wirtschaftsorganisationen"@de .
 
-:s543420
+:N543420
     a skos:Concept ;
-    skos:broader :s543400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543420" ;
     skos:prefLabel "Wirtschaftsverbände"@de .
 
-:s543430
+:N543430
     a skos:Concept ;
-    skos:broader :s543400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543430" ;
     skos:prefLabel "Industrie- und Handelskammern"@de .
 
-:s543440
+:N543440
     a skos:Concept ;
-    skos:broader :s543400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543440" ;
     skos:prefLabel "Verbraucherverbände"@de .
 
-:s543460
+:N543460
     a skos:Concept ;
-    skos:broader :s543400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543460" ;
     skos:prefLabel "Arbeitgebervereinigungen"@de .
 
-:s543480
+:N543480
     a skos:Concept ;
-    skos:broader :s543400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543480" ;
     skos:prefLabel "Gewerkschaften"@de .
 
-:s543600
+:N543600
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s543620, :s543630, :s543640, :s543660, :s543680 ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N543620, :N543630, :N543640, :N543660, :N543680 ;
     skos:notation "543600" ;
     skos:prefLabel "Arbeitsmarkt"@de .
 
-:s543620
+:N543620
     a skos:Concept ;
-    skos:broader :s543600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543620" ;
     skos:prefLabel "Unternehmer. Unternehmensführung"@de .
 
-:s543630
+:N543630
     a skos:Concept ;
-    skos:broader :s543600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543630" ;
     skos:prefLabel "Arbeitnehmer"@de .
 
-:s543640
+:N543640
     a skos:Concept ;
-    skos:broader :s543600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543640" ;
     skos:prefLabel "Freie Berufe"@de .
 
-:s543660
+:N543660
     a skos:Concept ;
-    skos:broader :s543600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543660" ;
     skos:prefLabel "Lohn und Einkommen"@de .
 
-:s543680
+:N543680
     a skos:Concept ;
-    skos:broader :s543600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N543600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543680" ;
     skos:prefLabel "Arbeitslosigkeit"@de .
 
-:s543800
+:N543800
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "543800" ;
     skos:prefLabel "Marketing"@de .
 
-:s544000
+:N544000
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s544010, :s544020, :s544030, :s544040, :s544050, :s544060, :s544090 ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N544010, :N544020, :N544030, :N544040, :N544050, :N544060, :N544090 ;
     skos:notation "544000" ;
     skos:prefLabel "Landwirtschaft"@de .
 
-:s544010
+:N544010
     a skos:Concept ;
-    skos:broader :s544000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544010" ;
     skos:prefLabel "Agrarpolitik"@de .
 
-:s544020
+:N544020
     a skos:Concept ;
-    skos:broader :s544000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544020" ;
     skos:prefLabel "Agrargeschichte"@de .
 
-:s544030
+:N544030
     a skos:Concept ;
-    skos:broader :s544000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544030" ;
     skos:prefLabel "Hofgeschichte"@de .
 
-:s544040
+:N544040
     a skos:Concept ;
-    skos:broader :s544000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544040" ;
     skos:prefLabel "Flurformen. Flurbereinigung"@de .
 
-:s544050
+:N544050
     a skos:Concept ;
-    skos:broader :s544000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s544052, :s544054, :s544056 ;
+    skos:broader :N544000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N544052, :N544054, :N544056 ;
     skos:notation "544050" ;
     skos:prefLabel "Landwirtschaftliche Arbeitskräfte"@de .
 
-:s544052
+:N544052
     a skos:Concept ;
-    skos:broader :s544050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544052" ;
     skos:prefLabel "Bauern"@de .
 
-:s544054
+:N544054
     a skos:Concept ;
-    skos:broader :s544050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544054" ;
     skos:prefLabel "Landfrauen"@de .
 
-:s544056
+:N544056
     a skos:Concept ;
-    skos:broader :s544050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544056" ;
     skos:prefLabel "Landarbeiter"@de .
 
-:s544060
+:N544060
     a skos:Concept ;
-    skos:broader :s544000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544060" ;
     skos:prefLabel "Landwirtschaftliche Betriebslehre"@de .
 
-:s544090
+:N544090
     a skos:Concept ;
-    skos:broader :s544000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544090" ;
     skos:prefLabel "Landwirtschaftsgenossenschaften"@de .
 
-:s544200
+:N544200
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s544210, :s544220, :s544230, :s544240, :s544250, :s544260, :s544280 ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N544210, :N544220, :N544230, :N544240, :N544250, :N544260, :N544280 ;
     skos:notation "544200" ;
     skos:prefLabel "Agrarproduktion"@de .
 
-:s544210
+:N544210
     a skos:Concept ;
-    skos:broader :s544200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544210" ;
     skos:prefLabel "Biologische Landwirtschaft"@de .
 
-:s544220
+:N544220
     a skos:Concept ;
-    skos:broader :s544200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544220" ;
     skos:prefLabel "Ackerbau"@de .
 
-:s544230
+:N544230
     a skos:Concept ;
-    skos:broader :s544200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544230" ;
     skos:prefLabel "Grünlandwirtschaft"@de .
 
-:s544240
+:N544240
     a skos:Concept ;
-    skos:broader :s544200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s544245 ;
+    skos:broader :N544200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N544245 ;
     skos:notation "544240" ;
     skos:prefLabel "Gartenbau"@de .
 
-:s544245
+:N544245
     a skos:Concept ;
-    skos:broader :s544240 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544240 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544245" ;
     skos:prefLabel "Baumschulen"@de .
 
-:s544250
+:N544250
     a skos:Concept ;
-    skos:broader :s544200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544250" ;
     skos:prefLabel "Obstbau"@de .
 
-:s544260
+:N544260
     a skos:Concept ;
-    skos:broader :s544200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544260" ;
     skos:prefLabel "Weinbau"@de .
 
-:s544280
+:N544280
     a skos:Concept ;
-    skos:broader :s544200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544280" ;
     skos:prefLabel "Tierzucht"@de .
 
-:s544400
+:N544400
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s544410, :s544420, :s544440, :s544450, :s544460 ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N544410, :N544420, :N544440, :N544450, :N544460 ;
     skos:notation "544400" ;
     skos:prefLabel "Forstwirtschaft"@de .
 
-:s544410
+:N544410
     a skos:Concept ;
-    skos:broader :s544400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544410" ;
     skos:prefLabel "Forstrecht"@de .
 
-:s544420
+:N544420
     a skos:Concept ;
-    skos:broader :s544400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544420" ;
     skos:prefLabel "Forstgeschichte"@de .
 
-:s544440
+:N544440
     a skos:Concept ;
-    skos:broader :s544400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544440" ;
     skos:prefLabel "Forstprodukte"@de .
 
-:s544450
+:N544450
     a skos:Concept ;
-    skos:broader :s544400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544450" ;
     skos:prefLabel "Einzelne Baumarten"@de .
 
-:s544460
+:N544460
     a skos:Concept ;
-    skos:broader :s544400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544460" ;
     skos:prefLabel "Wald"@de .
 
-:s544600
+:N544600
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s544610, :s544620, :s544640, :s544650, :s544660, :s544670 ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N544610, :N544620, :N544640, :N544650, :N544660, :N544670 ;
     skos:notation "544600" ;
     skos:prefLabel "Jagd. Fischfang"@de .
 
-:s544610
+:N544610
     a skos:Concept ;
-    skos:broader :s544600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544610" ;
     skos:prefLabel "Jagd"@de .
 
-:s544620
+:N544620
     a skos:Concept ;
-    skos:broader :s544600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544620" ;
     skos:prefLabel "Jagdrecht"@de .
 
-:s544640
+:N544640
     a skos:Concept ;
-    skos:broader :s544600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544640" ;
     skos:prefLabel "Wild"@de .
 
-:s544650
+:N544650
     a skos:Concept ;
-    skos:broader :s544600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544650" ;
     skos:prefLabel "Fischfang"@de .
 
-:s544660
+:N544660
     a skos:Concept ;
-    skos:broader :s544600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544660" ;
     skos:prefLabel "Fischereirecht"@de .
 
-:s544670
+:N544670
     a skos:Concept ;
-    skos:broader :s544600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N544600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "544670" ;
     skos:prefLabel "Fischzucht"@de .
 
-:s545000
+:N545000
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s545010, :s545020, :s545030, :s545040, :s545050, :s545060, :s545070, :s545080 ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N545010, :N545020, :N545030, :N545040, :N545050, :N545060, :N545070, :N545080 ;
     skos:notation "545000" ;
     skos:prefLabel "Bergbau"@de .
 
-:s545010
+:N545010
     a skos:Concept ;
-    skos:broader :s545000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N545000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "545010" ;
     skos:prefLabel "Bergrecht"@de .
 
-:s545020
+:N545020
     a skos:Concept ;
-    skos:broader :s545000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N545000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "545020" ;
     skos:prefLabel "Bergbaugeschichte"@de .
 
-:s545030
+:N545030
     a skos:Concept ;
-    skos:broader :s545000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N545000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "545030" ;
     skos:prefLabel "Kohlenbergbau"@de .
 
-:s545040
+:N545040
     a skos:Concept ;
-    skos:broader :s545000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N545000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "545040" ;
     skos:prefLabel "Gesteinsabbau"@de .
 
-:s545050
+:N545050
     a skos:Concept ;
-    skos:broader :s545000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N545000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "545050" ;
     skos:prefLabel "Erzbergbau"@de .
 
-:s545060
+:N545060
     a skos:Concept ;
-    skos:broader :s545000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N545000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "545060" ;
     skos:prefLabel "Salz- und Kalibergbau"@de .
 
-:s545070
+:N545070
     a skos:Concept ;
-    skos:broader :s545000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N545000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "545070" ;
     skos:prefLabel "Erdöl"@de .
 
-:s545080
+:N545080
     a skos:Concept ;
-    skos:broader :s545000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N545000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "545080" ;
     skos:prefLabel "Erdgas"@de .
 
-:s546000
+:N546000
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s546020, :s546040, :s546050, :s546060 ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N546020, :N546040, :N546050, :N546060 ;
     skos:notation "546000" ;
     skos:prefLabel "Energiewirtschaft"@de .
 
-:s546020
+:N546020
     a skos:Concept ;
-    skos:broader :s546000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s546022, :s546024, :s546026, :s546028 ;
+    skos:broader :N546000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N546022, :N546024, :N546026, :N546028 ;
     skos:notation "546020" ;
     skos:prefLabel "Elektrizitätsversorgung"@de .
 
-:s546022
+:N546022
     a skos:Concept ;
-    skos:broader :s546020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N546020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "546022" ;
     skos:prefLabel "Wasserkraftwerke"@de .
 
-:s546024
+:N546024
     a skos:Concept ;
-    skos:broader :s546020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N546020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "546024" ;
     skos:prefLabel "Wärmekraftwerke"@de .
 
-:s546026
+:N546026
     a skos:Concept ;
-    skos:broader :s546020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N546020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "546026" ;
     skos:prefLabel "Kernkraftwerke"@de .
 
-:s546028
+:N546028
     a skos:Concept ;
-    skos:broader :s546020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N546020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "546028" ;
     skos:prefLabel "Sonstige Kraftwerke"@de .
 
-:s546040
+:N546040
     a skos:Concept ;
-    skos:broader :s546000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N546000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "546040" ;
     skos:prefLabel "Gasversorgung"@de .
 
-:s546050
+:N546050
     a skos:Concept ;
-    skos:broader :s546000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N546000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "546050" ;
     skos:prefLabel "Fernwärme"@de .
 
-:s546060
+:N546060
     a skos:Concept ;
-    skos:broader :s546000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N546000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "546060" ;
     skos:prefLabel "Verbundwirtschaft"@de .
 
-:s547000
+:N547000
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s547020, :s547030, :s547040, :s547050, :s547060 ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N547020, :N547030, :N547040, :N547050, :N547060 ;
     skos:notation "547000" ;
     skos:prefLabel "Handwerk"@de .
 
-:s547020
+:N547020
     a skos:Concept ;
-    skos:broader :s547000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N547000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "547020" ;
     skos:prefLabel "Handwerksgeschichte"@de .
 
-:s547030
+:N547030
     a skos:Concept ;
-    skos:broader :s547000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N547000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "547030" ;
     skos:prefLabel "Einzelne Handwerke"@de .
 
-:s547040
+:N547040
     a skos:Concept ;
-    skos:broader :s547000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N547000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "547040" ;
     skos:prefLabel "Handwerksgenossenschaften"@de .
 
-:s547050
+:N547050
     a skos:Concept ;
-    skos:broader :s547000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N547000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "547050" ;
     skos:prefLabel "Handwerkskammern"@de .
 
-:s547060
+:N547060
     a skos:Concept ;
-    skos:broader :s547000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N547000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "547060" ;
     skos:prefLabel "Innungen"@de .
 
-:s547400
+:N547400
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s547420, :s547440, :s547460, :s547480 ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N547420, :N547440, :N547460, :N547480 ;
     skos:notation "547400" ;
     skos:prefLabel "Industrie"@de .
 
-:s547420
+:N547420
     a skos:Concept ;
-    skos:broader :s547400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N547400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "547420" ;
     skos:prefLabel "Industriegeschichte"@de .
 
-:s547440
+:N547440
     a skos:Concept ;
-    skos:broader :s547400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N547400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "547440" ;
     skos:prefLabel "Einzelne Industriezweige"@de .
 
-:s547460
+:N547460
     a skos:Concept ;
-    skos:broader :s547400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N547400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "547460" ;
     skos:prefLabel "Industriebetriebe"@de .
 
-:s547480
+:N547480
     a skos:Concept ;
-    skos:broader :s547400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N547400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "547480" ;
     skos:prefLabel "Produktionsgenossenschaften"@de .
 
-:s547600
+:N547600
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "547600" ;
     skos:prefLabel "Technik"@de .
 
-:s548000
+:N548000
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s548010, :s548020, :s548030, :s548040, :s548050, :s548060, :s548090 ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N548010, :N548020, :N548030, :N548040, :N548050, :N548060, :N548090 ;
     skos:notation "548000" ;
     skos:prefLabel "Handel"@de .
 
-:s548010
+:N548010
     a skos:Concept ;
-    skos:broader :s548000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N548000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548010" ;
     skos:prefLabel "Handelsrecht"@de .
 
-:s548020
+:N548020
     a skos:Concept ;
-    skos:broader :s548000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N548000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548020" ;
     skos:prefLabel "Handelsgeschichte"@de .
 
-:s548030
+:N548030
     a skos:Concept ;
-    skos:broader :s548000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N548000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548030" ;
     skos:prefLabel "Handelsformen"@de .
 
-:s548040
+:N548040
     a skos:Concept ;
-    skos:broader :s548000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s548045 ;
+    skos:broader :N548000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N548045 ;
     skos:notation "548040" ;
     skos:prefLabel "Messen. Ausstellungen"@de .
 
-:s548045
+:N548045
     a skos:Concept ;
-    skos:broader :s548040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N548040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548045" ;
     skos:prefLabel "Märkte"@de .
 
-:s548050
+:N548050
     a skos:Concept ;
-    skos:broader :s548000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N548000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548050" ;
     skos:prefLabel "Handelsbetriebe"@de .
 
-:s548060
+:N548060
     a skos:Concept ;
-    skos:broader :s548000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N548000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548060" ;
     skos:prefLabel "Handelsgüter"@de .
 
-:s548090
+:N548090
     a skos:Concept ;
-    skos:broader :s548000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N548000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548090" ;
     skos:prefLabel "Einkaufsgenossenschaften"@de .
 
-:s548200
+:N548200
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548200" ;
     skos:prefLabel "Dienstleistungssektor"@de .
 
-:s548300
+:N548300
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548300" ;
     skos:prefLabel "Öffentliche Unternehmen"@de .
 
-:s548400
+:N548400
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548400" ;
     skos:prefLabel "Banken"@de .
 
-:s548500
+:N548500
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548500" ;
     skos:prefLabel "Börsen"@de .
 
-:s548600
+:N548600
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548600" ;
     skos:prefLabel "Versicherungen"@de .
 
-:s548800
+:N548800
     a skos:Concept ;
-    skos:broader :s540000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s548820, :s548840, :s548850, :s548870 ;
+    skos:broader :N540000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N548820, :N548840, :N548850, :N548870 ;
     skos:notation "548800" ;
     skos:prefLabel "Fremdenverkehr"@de .
 
-:s548820
+:N548820
     a skos:Concept ;
-    skos:broader :s548800 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N548800 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548820" ;
     skos:prefLabel "Kurorte"@de .
 
-:s548840
+:N548840
     a skos:Concept ;
-    skos:broader :s548800 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N548800 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548840" ;
     skos:prefLabel "Naherholung"@de .
 
-:s548850
+:N548850
     a skos:Concept ;
-    skos:broader :s548800 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N548800 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548850" ;
     skos:prefLabel "Gastgewerbe"@de .
 
-:s548870
+:N548870
     a skos:Concept ;
-    skos:broader :s548800 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N548800 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "548870" ;
     skos:prefLabel "Jugendherbergen"@de .
 
-:s550000
+:N550000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s5 ;
-    skos:narrower :s550100, :s551000, :s552000, :s553000, :s554000, :s555000, :s556000, :s557000, :s558000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N5 ;
+    skos:narrower :N550100, :N551000, :N552000, :N553000, :N554000, :N555000, :N556000, :N557000, :N558000 ;
     skos:notation "550000" ;
     skos:prefLabel "Verkehr"@de .
 
-:s550100
+:N550100
     a skos:Concept ;
-    skos:broader :s550000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N550000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "550100" ;
     skos:prefLabel "Verkehr - Allgemeines"@de .
 
-:s551000
+:N551000
     a skos:Concept ;
-    skos:broader :s550000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N550000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "551000" ;
     skos:prefLabel "Verkehrsrecht"@de .
 
-:s552000
+:N552000
     a skos:Concept ;
-    skos:broader :s550000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N550000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "552000" ;
     skos:prefLabel "Verkehrsgeschichte"@de .
 
-:s553000
+:N553000
     a skos:Concept ;
-    skos:broader :s550000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N550000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "553000" ;
     skos:prefLabel "Straßenverkehr"@de .
 
-:s554000
+:N554000
     a skos:Concept ;
-    skos:broader :s550000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N550000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "554000" ;
     skos:prefLabel "Öffentlicher Personennahverkehr"@de .
 
-:s555000
+:N555000
     a skos:Concept ;
-    skos:broader :s550000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s555020 ;
+    skos:broader :N550000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N555020 ;
     skos:notation "555000" ;
     skos:prefLabel "Eisenbahn"@de .
 
-:s555020
+:N555020
     a skos:Concept ;
-    skos:broader :s555000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N555000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "555020" ;
     skos:prefLabel "Eisenbahngeschichte"@de .
 
-:s556000
+:N556000
     a skos:Concept ;
-    skos:broader :s550000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N550000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "556000" ;
     skos:prefLabel "Luftverkehr"@de .
 
-:s557000
+:N557000
     a skos:Concept ;
-    skos:broader :s550000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s557020, :s557040, :s557060 ;
+    skos:broader :N550000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N557020, :N557040, :N557060 ;
     skos:notation "557000" ;
     skos:prefLabel "Schiffahrt"@de .
 
-:s557020
+:N557020
     a skos:Concept ;
-    skos:broader :s557000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N557000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "557020" ;
     skos:prefLabel "Schiffahrtsgeschichte"@de .
 
-:s557040
+:N557040
     a skos:Concept ;
-    skos:broader :s557000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N557000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "557040" ;
     skos:prefLabel "Kanäle"@de .
 
-:s557060
+:N557060
     a skos:Concept ;
-    skos:broader :s557000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N557000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "557060" ;
     skos:prefLabel "Häfen"@de .
 
-:s558000
+:N558000
     a skos:Concept ;
-    skos:broader :s550000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s558020, :s558050 ;
+    skos:broader :N550000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N558020, :N558050 ;
     skos:notation "558000" ;
     skos:prefLabel "Post- und Fernmeldewesen"@de .
 
-:s558020
+:N558020
     a skos:Concept ;
-    skos:broader :s558000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N558000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "558020" ;
     skos:prefLabel "Postgeschichte"@de .
 
-:s558050
+:N558050
     a skos:Concept ;
-    skos:broader :s558000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N558000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "558050" ;
     skos:prefLabel "Fernmeldewesen. Telekommunikation"@de .
 
-:s560000
+:N560000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s5 ;
-    skos:narrower :s560100, :s562000, :s562300, :s564000, :s566000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N5 ;
+    skos:narrower :N560100, :N562000, :N562300, :N564000, :N566000 ;
     skos:notation "560000" ;
     skos:prefLabel "Siedlung"@de .
 
-:s560100
+:N560100
     a skos:Concept ;
-    skos:broader :s560000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N560000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "560100" ;
     skos:prefLabel "Siedlung - Allgemeines"@de .
 
-:s562000
+:N562000
     a skos:Concept ;
-    skos:broader :s560000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s562040, :s562060 ;
+    skos:broader :N560000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N562040, :N562060 ;
     skos:notation "562000" ;
     skos:prefLabel "Siedlungsgeschichte"@de .
 
-:s562040
+:N562040
     a skos:Concept ;
-    skos:broader :s562000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N562000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "562040" ;
     skos:prefLabel "Orts- und Flurwüstungen"@de .
 
-:s562060
+:N562060
     a skos:Concept ;
-    skos:broader :s562000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N562000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "562060" ;
     skos:prefLabel "Marken und Allmenden"@de .
 
-:s562300
+:N562300
     a skos:Concept ;
-    skos:broader :s560000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N560000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "562300" ;
     skos:prefLabel "Kulturlandschaft"@de .
 
-:s564000
+:N564000
     a skos:Concept ;
-    skos:broader :s560000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s564040, :s564050, :s564080 ;
+    skos:broader :N560000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N564040, :N564050, :N564080 ;
     skos:notation "564000" ;
     skos:prefLabel "Ländliche Siedlung"@de .
 
-:s564040
+:N564040
     a skos:Concept ;
-    skos:broader :s564000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N564000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "564040" ;
     skos:prefLabel "Siedlungsformen"@de .
 
-:s564050
+:N564050
     a skos:Concept ;
-    skos:broader :s564000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s564051, :s564052 ;
+    skos:broader :N564000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N564051, :N564052 ;
     skos:notation "564050" ;
     skos:prefLabel "Dorftopographie"@de .
 
-:s564051
+:N564051
     a skos:Concept ;
-    skos:broader :s564050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N564050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "564051" ;
     skos:prefLabel "Dorfplätze"@de .
 
-:s564052
+:N564052
     a skos:Concept ;
-    skos:broader :s564050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N564050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "564052" ;
     skos:prefLabel "Dorfstraßen"@de .
 
-:s564080
+:N564080
     a skos:Concept ;
-    skos:broader :s564000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N564000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "564080" ;
     skos:prefLabel "Dorferneuerung"@de .
 
-:s566000
+:N566000
     a skos:Concept ;
-    skos:broader :s560000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s566010, :s566020, :s566040, :s566050, :s566060, :s566070, :s566080 ;
+    skos:broader :N560000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N566010, :N566020, :N566040, :N566050, :N566060, :N566070, :N566080 ;
     skos:notation "566000" ;
     skos:prefLabel "Städtische Siedlung"@de .
 
-:s566010
+:N566010
     a skos:Concept ;
-    skos:broader :s566000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566010" ;
     skos:prefLabel "Stadttypen"@de .
 
-:s566020
+:N566020
     a skos:Concept ;
-    skos:broader :s566000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566020" ;
     skos:prefLabel "Städtische Siedlungsformen"@de .
 
-:s566040
+:N566040
     a skos:Concept ;
-    skos:broader :s566000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s566041, :s566042, :s566043, :s566044, :s566045, :s566046 ;
+    skos:broader :N566000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N566041, :N566042, :N566043, :N566044, :N566045, :N566046 ;
     skos:notation "566040" ;
     skos:prefLabel "Stadtstruktur"@de .
 
-:s566041
+:N566041
     a skos:Concept ;
-    skos:broader :s566040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566041" ;
     skos:prefLabel "Innenstadt"@de .
 
-:s566042
+:N566042
     a skos:Concept ;
-    skos:broader :s566040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566042" ;
     skos:prefLabel "Vororte. Stadtteile"@de .
 
-:s566043
+:N566043
     a skos:Concept ;
-    skos:broader :s566040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566043" ;
     skos:prefLabel "Geschäftsviertel"@de .
 
-:s566044
+:N566044
     a skos:Concept ;
-    skos:broader :s566040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566044" ;
     skos:prefLabel "Gewerbegebiete"@de .
 
-:s566045
+:N566045
     a skos:Concept ;
-    skos:broader :s566040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566045" ;
     skos:prefLabel "Wohngebiete"@de .
 
-:s566046
+:N566046
     a skos:Concept ;
-    skos:broader :s566040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566046" ;
     skos:prefLabel "Erholungsgebiete"@de .
 
-:s566050
+:N566050
     a skos:Concept ;
-    skos:broader :s566000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s566051, :s566052, :s566053 ;
+    skos:broader :N566000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N566051, :N566052, :N566053 ;
     skos:notation "566050" ;
     skos:prefLabel "Stadttopographie"@de .
 
-:s566051
+:N566051
     a skos:Concept ;
-    skos:broader :s566050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566051" ;
     skos:prefLabel "Plätze"@de .
 
-:s566052
+:N566052
     a skos:Concept ;
-    skos:broader :s566050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566052" ;
     skos:prefLabel "Straßen"@de .
 
-:s566053
+:N566053
     a skos:Concept ;
-    skos:broader :s566050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566053" ;
     skos:prefLabel "Gebäude"@de .
 
-:s566060
+:N566060
     a skos:Concept ;
-    skos:broader :s566000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566060" ;
     skos:prefLabel "Verstädterung"@de .
 
-:s566070
+:N566070
     a skos:Concept ;
-    skos:broader :s566000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566070" ;
     skos:prefLabel "Ballungsräume"@de .
 
-:s566080
+:N566080
     a skos:Concept ;
-    skos:broader :s566000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N566000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "566080" ;
     skos:prefLabel "Stadt-Umland-Beziehungen"@de .
 
-:s570000
+:N570000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s5 ;
-    skos:narrower :s570100, :s572000, :s574000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N5 ;
+    skos:narrower :N570100, :N572000, :N574000 ;
     skos:notation "570000" ;
     skos:prefLabel "Raumordnung und Städtebau"@de .
 
-:s570100
+:N570100
     a skos:Concept ;
-    skos:broader :s570000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N570000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "570100" ;
     skos:prefLabel "Raumordnung und Städtebau - Allgemeines"@de .
 
-:s572000
+:N572000
     a skos:Concept ;
-    skos:broader :s570000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s572020, :s572030, :s572050, :s572060 ;
+    skos:broader :N570000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N572020, :N572030, :N572050, :N572060 ;
     skos:notation "572000" ;
     skos:prefLabel "Raumordnung"@de .
 
-:s572020
+:N572020
     a skos:Concept ;
-    skos:broader :s572000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N572000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "572020" ;
     skos:prefLabel "Landesplanung"@de .
 
-:s572030
+:N572030
     a skos:Concept ;
-    skos:broader :s572000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N572000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "572030" ;
     skos:prefLabel "Regionalplanung"@de .
 
-:s572050
+:N572050
     a skos:Concept ;
-    skos:broader :s572000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N572000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "572050" ;
     skos:prefLabel "Landschaftsplanung"@de .
 
-:s572060
+:N572060
     a skos:Concept ;
-    skos:broader :s572000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N572000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "572060" ;
     skos:prefLabel "Kommunalplanung"@de .
 
-:s574000
+:N574000
     a skos:Concept ;
-    skos:broader :s570000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s574020, :s574030, :s574040, :s574050, :s574060 ;
+    skos:broader :N570000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N574020, :N574030, :N574040, :N574050, :N574060 ;
     skos:notation "574000" ;
     skos:prefLabel "Bauwesen"@de .
 
-:s574020
+:N574020
     a skos:Concept ;
-    skos:broader :s574000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N574000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "574020" ;
     skos:prefLabel "Bau- und Bodenrecht"@de .
 
-:s574030
+:N574030
     a skos:Concept ;
-    skos:broader :s574000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N574000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "574030" ;
     skos:prefLabel "Städtebau"@de .
 
-:s574040
+:N574040
     a skos:Concept ;
-    skos:broader :s574000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N574000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "574040" ;
     skos:prefLabel "Straßenbau"@de .
 
-:s574050
+:N574050
     a skos:Concept ;
-    skos:broader :s574000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N574000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "574050" ;
     skos:prefLabel "Wohnungsbau"@de .
 
-:s574060
+:N574060
     a skos:Concept ;
-    skos:broader :s574000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N574000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "574060" ;
     skos:prefLabel "Wohnungswirtschaft"@de .
 
-:s580000
+:N580000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s5 ;
-    skos:narrower :s580100, :s582000, :s584000, :s586000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N5 ;
+    skos:narrower :N580100, :N582000, :N584000, :N586000 ;
     skos:notation "580000" ;
     skos:prefLabel "Umwelt- und Naturschutz"@de .
 
-:s580100
+:N580100
     a skos:Concept ;
-    skos:broader :s580000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N580000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "580100" ;
     skos:prefLabel "Umwelt- und Naturschutz - Allgemeines"@de .
 
-:s582000
+:N582000
     a skos:Concept ;
-    skos:broader :s580000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s582020, :s582030, :s582040, :s582050, :s582060, :s582070 ;
+    skos:broader :N580000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N582020, :N582030, :N582040, :N582050, :N582060, :N582070 ;
     skos:notation "582000" ;
     skos:prefLabel "Umweltschutz"@de .
 
-:s582020
+:N582020
     a skos:Concept ;
-    skos:broader :s582000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N582000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "582020" ;
     skos:prefLabel "Bodenschutz"@de .
 
-:s582030
+:N582030
     a skos:Concept ;
-    skos:broader :s582000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N582000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "582030" ;
     skos:prefLabel "Luftverschmutzung"@de .
 
-:s582040
+:N582040
     a skos:Concept ;
-    skos:broader :s582000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N582000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "582040" ;
     skos:prefLabel "Lärmbelastung"@de .
 
-:s582050
+:N582050
     a skos:Concept ;
-    skos:broader :s582000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s582052, :s582054 ;
+    skos:broader :N582000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N582052, :N582054 ;
     skos:notation "582050" ;
     skos:prefLabel "Gewässerschutz"@de .
 
-:s582052
+:N582052
     a skos:Concept ;
-    skos:broader :s582050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N582050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "582052" ;
     skos:prefLabel "Abwasser"@de .
 
-:s582054
+:N582054
     a skos:Concept ;
-    skos:broader :s582050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N582050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "582054" ;
     skos:prefLabel "Kanalisation"@de .
 
-:s582060
+:N582060
     a skos:Concept ;
-    skos:broader :s582000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N582000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "582060" ;
     skos:prefLabel "Abfallbeseitigung"@de .
 
-:s582070
+:N582070
     a skos:Concept ;
-    skos:broader :s582000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N582000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "582070" ;
     skos:prefLabel "Strahlenbelastung"@de .
 
-:s584000
+:N584000
     a skos:Concept ;
-    skos:broader :s580000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s584020, :s584040, :s584050, :s584060, :s584070, :s584080, :s584090 ;
+    skos:broader :N580000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N584020, :N584040, :N584050, :N584060, :N584070, :N584080, :N584090 ;
     skos:notation "584000" ;
     skos:prefLabel "Naturschutz. Landschaftspflege"@de .
 
-:s584020
+:N584020
     a skos:Concept ;
-    skos:broader :s584000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N584000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "584020" ;
     skos:prefLabel "Naturgefährdung"@de .
 
-:s584040
+:N584040
     a skos:Concept ;
-    skos:broader :s584000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N584000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "584040" ;
     skos:prefLabel "Naturdenkmäler"@de .
 
-:s584050
+:N584050
     a skos:Concept ;
-    skos:broader :s584000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N584000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "584050" ;
     skos:prefLabel "Pflanzenschutz"@de .
 
-:s584060
+:N584060
     a skos:Concept ;
-    skos:broader :s584000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N584000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "584060" ;
     skos:prefLabel "Tierschutz"@de .
 
-:s584070
+:N584070
     a skos:Concept ;
-    skos:broader :s584000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N584000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "584070" ;
     skos:prefLabel "Naturschutzgebiete"@de .
 
-:s584080
+:N584080
     a skos:Concept ;
-    skos:broader :s584000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N584000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "584080" ;
     skos:prefLabel "Naturparke"@de .
 
-:s584090
+:N584090
     a skos:Concept ;
-    skos:broader :s584000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N584000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "584090" ;
     skos:prefLabel "Landschaftsentwicklung"@de .
 
-:s586000
+:N586000
     a skos:Concept ;
-    skos:broader :s580000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s586020, :s586030, :s586040, :s586070, :s586080 ;
+    skos:broader :N580000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N586020, :N586030, :N586040, :N586070, :N586080 ;
     skos:notation "586000" ;
     skos:prefLabel "Grünanlagen"@de .
 
-:s586020
+:N586020
     a skos:Concept ;
-    skos:broader :s586000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N586000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "586020" ;
     skos:prefLabel "Parks"@de .
 
-:s586030
+:N586030
     a skos:Concept ;
-    skos:broader :s586000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N586000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "586030" ;
     skos:prefLabel "Botanische Gärten"@de .
 
-:s586040
+:N586040
     a skos:Concept ;
-    skos:broader :s586000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N586000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "586040" ;
     skos:prefLabel "Zoologische Gärten"@de .
 
-:s586070
+:N586070
     a skos:Concept ;
-    skos:broader :s586000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N586000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "586070" ;
     skos:prefLabel "Bundesgartenschau"@de .
 
-:s586080
+:N586080
     a skos:Concept ;
-    skos:broader :s586000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N586000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "586080" ;
     skos:prefLabel "Landesgartenschau"@de .
 
-:s610000
+:N610000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s6 ;
-    skos:narrower :s610100, :s611000, :s612000, :s612500, :s613000, :s615000, :s616000, :s617000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N6 ;
+    skos:narrower :N610100, :N611000, :N612000, :N612500, :N613000, :N615000, :N616000, :N617000 ;
     skos:notation "610000" ;
     skos:prefLabel "Christliche Kirchen"@de .
 
-:s610100
+:N610100
     a skos:Concept ;
-    skos:broader :s610000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N610000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "610100" ;
     skos:prefLabel "Christliche Kirchen - Allgemeines"@de .
 
-:s611000
+:N611000
     a skos:Concept ;
-    skos:broader :s610000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s611010, :s611020, :s611030, :s611040, :s611050, :s611060, :s611070, :s611080, :s611090 ;
+    skos:broader :N610000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N611010, :N611020, :N611030, :N611040, :N611050, :N611060, :N611070, :N611080, :N611090 ;
     skos:notation "611000" ;
     skos:prefLabel "Katholische Kirche"@de .
 
-:s611010
+:N611010
     a skos:Concept ;
-    skos:broader :s611000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611010" ;
     skos:prefLabel "Kirchengeschichte"@de .
 
-:s611020
+:N611020
     a skos:Concept ;
-    skos:broader :s611000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s611025 ;
+    skos:broader :N611000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N611025 ;
     skos:notation "611020" ;
     skos:prefLabel "Kirchenrecht"@de .
 
-:s611025
+:N611025
     a skos:Concept ;
-    skos:broader :s611020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611025" ;
     skos:prefLabel "Kirchenverwaltung"@de .
 
-:s611030
+:N611030
     a skos:Concept ;
-    skos:broader :s611000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611030" ;
     skos:prefLabel "Kirchengemeinden"@de .
 
-:s611040
+:N611040
     a skos:Concept ;
-    skos:broader :s611000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s611042, :s611043, :s611044, :s611045 ;
+    skos:broader :N611000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N611042, :N611043, :N611044, :N611045 ;
     skos:notation "611040" ;
     skos:prefLabel "Kirchliches Leben"@de .
 
-:s611042
+:N611042
     a skos:Concept ;
-    skos:broader :s611040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611042" ;
     skos:prefLabel "Seelsorge"@de .
 
-:s611043
+:N611043
     a skos:Concept ;
-    skos:broader :s611040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611043" ;
     skos:prefLabel "Kirchliche Laienarbeit"@de .
 
-:s611044
+:N611044
     a skos:Concept ;
-    skos:broader :s611040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611044" ;
     skos:prefLabel "Kirchliche Vereine und Verbände"@de .
 
-:s611045
+:N611045
     a skos:Concept ;
-    skos:broader :s611040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611045" ;
     skos:prefLabel "Kirchliche Stiftungen"@de .
 
-:s611050
+:N611050
     a skos:Concept ;
-    skos:broader :s611000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611050" ;
     skos:prefLabel "Geistliche. Ordensleute"@de .
 
-:s611060
+:N611060
     a skos:Concept ;
-    skos:broader :s611000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611060" ;
     skos:prefLabel "Klöster. Stifte"@de .
 
-:s611070
+:N611070
     a skos:Concept ;
-    skos:broader :s611000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611070" ;
     skos:prefLabel "Orden"@de .
 
-:s611080
+:N611080
     a skos:Concept ;
-    skos:broader :s611000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s611082, :s611083, :s611084, :s611085 ;
+    skos:broader :N611000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N611082, :N611083, :N611084, :N611085 ;
     skos:notation "611080" ;
     skos:prefLabel "Kultus"@de .
 
-:s611082
+:N611082
     a skos:Concept ;
-    skos:broader :s611080 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611080 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611082" ;
     skos:prefLabel "Sakramente"@de .
 
-:s611083
+:N611083
     a skos:Concept ;
-    skos:broader :s611080 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611080 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611083" ;
     skos:prefLabel "Kirchenfeste"@de .
 
-:s611084
+:N611084
     a skos:Concept ;
-    skos:broader :s611080 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611080 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611084" ;
     skos:prefLabel "Prozessionen"@de .
 
-:s611085
+:N611085
     a skos:Concept ;
-    skos:broader :s611080 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611080 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611085" ;
     skos:prefLabel "Wallfahrten"@de .
 
-:s611090
+:N611090
     a skos:Concept ;
-    skos:broader :s611000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N611000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "611090" ;
     skos:prefLabel "Heilige. Heiligenverehrung"@de .
 
-:s612000
+:N612000
     a skos:Concept ;
-    skos:broader :s610000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s612020, :s612030, :s612040, :s612050, :s612070, :s612080 ;
+    skos:broader :N610000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N612020, :N612030, :N612040, :N612050, :N612070, :N612080 ;
     skos:notation "612000" ;
     skos:prefLabel "Reformation"@de .
 
-:s612020
+:N612020
     a skos:Concept ;
-    skos:broader :s612000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s612025 ;
+    skos:broader :N612000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N612025 ;
     skos:notation "612020" ;
     skos:prefLabel "Calvinismus"@de .
 
-:s612025
+:N612025
     a skos:Concept ;
-    skos:broader :s612020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N612020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "612025" ;
     skos:prefLabel "Zwinglianer"@de .
 
-:s612030
+:N612030
     a skos:Concept ;
-    skos:broader :s612000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N612000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "612030" ;
     skos:prefLabel "Täufer"@de .
 
-:s612040
+:N612040
     a skos:Concept ;
-    skos:broader :s612000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N612000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "612040" ;
     skos:prefLabel "Schwärmer"@de .
 
-:s612050
+:N612050
     a skos:Concept ;
-    skos:broader :s612000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N612000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "612050" ;
     skos:prefLabel "Reformatoren"@de .
 
-:s612070
+:N612070
     a skos:Concept ;
-    skos:broader :s612000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N612000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "612070" ;
     skos:prefLabel "Glaubensflüchtlinge"@de .
 
-:s612080
+:N612080
     a skos:Concept ;
-    skos:broader :s612000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N612000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "612080" ;
     skos:prefLabel "Hugenotten"@de .
 
-:s612500
+:N612500
     a skos:Concept ;
-    skos:broader :s610000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N610000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "612500" ;
     skos:prefLabel "Gegenreformation"@de .
 
-:s613000
+:N613000
     a skos:Concept ;
-    skos:broader :s610000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s613010, :s613020, :s613030, :s613040, :s613050, :s613070, :s613090 ;
+    skos:broader :N610000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N613010, :N613020, :N613030, :N613040, :N613050, :N613070, :N613090 ;
     skos:notation "613000" ;
     skos:prefLabel "Evangelische Kirche"@de .
 
-:s613010
+:N613010
     a skos:Concept ;
-    skos:broader :s613000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N613000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "613010" ;
     skos:prefLabel "Kirchengeschichte"@de .
 
-:s613020
+:N613020
     a skos:Concept ;
-    skos:broader :s613000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s613025 ;
+    skos:broader :N613000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N613025 ;
     skos:notation "613020" ;
     skos:prefLabel "Kirchenrecht"@de .
 
-:s613025
+:N613025
     a skos:Concept ;
-    skos:broader :s613020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N613020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "613025" ;
     skos:prefLabel "Kirchenverwaltung"@de .
 
-:s613030
+:N613030
     a skos:Concept ;
-    skos:broader :s613000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N613000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "613030" ;
     skos:prefLabel "Kirchengemeinden"@de .
 
-:s613040
+:N613040
     a skos:Concept ;
-    skos:broader :s613000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s613042, :s613043, :s613044, :s613045 ;
+    skos:broader :N613000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N613042, :N613043, :N613044, :N613045 ;
     skos:notation "613040" ;
     skos:prefLabel "Kirchliches Leben"@de .
 
-:s613042
+:N613042
     a skos:Concept ;
-    skos:broader :s613040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N613040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "613042" ;
     skos:prefLabel "Seelsorge"@de .
 
-:s613043
+:N613043
     a skos:Concept ;
-    skos:broader :s613040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N613040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "613043" ;
     skos:prefLabel "Diakonie"@de .
 
-:s613044
+:N613044
     a skos:Concept ;
-    skos:broader :s613040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N613040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "613044" ;
     skos:prefLabel "Kirchliche Vereine und Verbände"@de .
 
-:s613045
+:N613045
     a skos:Concept ;
-    skos:broader :s613040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N613040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "613045" ;
     skos:prefLabel "Kirchliche Stiftungen"@de .
 
-:s613050
+:N613050
     a skos:Concept ;
-    skos:broader :s613000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N613000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "613050" ;
     skos:prefLabel "Pfarrer. Geistliche"@de .
 
-:s613070
+:N613070
     a skos:Concept ;
-    skos:broader :s613000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s613072, :s613073 ;
+    skos:broader :N613000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N613072, :N613073 ;
     skos:notation "613070" ;
     skos:prefLabel "Kultus"@de .
 
-:s613072
+:N613072
     a skos:Concept ;
-    skos:broader :s613070 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N613070 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "613072" ;
     skos:prefLabel "Sakramente"@de .
 
-:s613073
+:N613073
     a skos:Concept ;
-    skos:broader :s613070 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N613070 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "613073" ;
     skos:prefLabel "Kirchenfeste"@de .
 
-:s613090
+:N613090
     a skos:Concept ;
-    skos:broader :s613000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N613000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "613090" ;
     skos:prefLabel "Freikirchen"@de .
 
-:s615000
+:N615000
     a skos:Concept ;
-    skos:broader :s610000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s615020, :s615040, :s615070 ;
+    skos:broader :N610000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N615020, :N615040, :N615070 ;
     skos:notation "615000" ;
     skos:prefLabel "Sonstige christliche Kirchen. Sekten"@de .
 
-:s615020
+:N615020
     a skos:Concept ;
-    skos:broader :s615000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N615000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "615020" ;
     skos:prefLabel "Orthodoxe Kirche"@de .
 
-:s615040
+:N615040
     a skos:Concept ;
-    skos:broader :s615000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N615000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "615040" ;
     skos:prefLabel "Altkatholische Kirche"@de .
 
-:s615070
+:N615070
     a skos:Concept ;
-    skos:broader :s615000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N615000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "615070" ;
     skos:prefLabel "Sekten"@de .
 
-:s616000
+:N616000
     a skos:Concept ;
-    skos:broader :s610000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N610000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "616000" ;
     skos:prefLabel "Ökumene"@de .
 
-:s617000
+:N617000
     a skos:Concept ;
-    skos:broader :s610000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s617030, :s617050 ;
+    skos:broader :N610000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N617030, :N617050 ;
     skos:notation "617000" ;
     skos:prefLabel "Bestattungswesen"@de .
 
-:s617030
+:N617030
     a skos:Concept ;
-    skos:broader :s617000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N617000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "617030" ;
     skos:prefLabel "Friedhöfe"@de .
 
-:s617050
+:N617050
     a skos:Concept ;
-    skos:broader :s617000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N617000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "617050" ;
     skos:prefLabel "Grabmale"@de .
 
-:s630000
+:N630000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s6 ;
-    skos:narrower :s630100, :s631000, :s632000, :s635000, :s636000, :s637000, :s638000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N6 ;
+    skos:narrower :N630100, :N631000, :N632000, :N635000, :N636000, :N637000, :N638000 ;
     skos:notation "630000" ;
     skos:prefLabel "Judentum"@de .
 
-:s630100
+:N630100
     a skos:Concept ;
-    skos:broader :s630000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N630000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "630100" ;
     skos:prefLabel "Judentum - Allgemeines"@de .
 
-:s631000
+:N631000
     a skos:Concept ;
-    skos:broader :s630000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N630000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "631000" ;
     skos:prefLabel "Jüdische Religion"@de .
 
-:s632000
+:N632000
     a skos:Concept ;
-    skos:broader :s630000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s632050 ;
+    skos:broader :N630000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N632050 ;
     skos:notation "632000" ;
     skos:prefLabel "Geschichte der Juden"@de .
 
-:s632050
+:N632050
     a skos:Concept ;
-    skos:broader :s632000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N632000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "632050" ;
     skos:prefLabel "Judenverfolgung"@de .
 
-:s635000
+:N635000
     a skos:Concept ;
-    skos:broader :s630000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N630000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "635000" ;
     skos:prefLabel "Jüdische Volkskunde"@de .
 
-:s636000
+:N636000
     a skos:Concept ;
-    skos:broader :s630000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N630000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "636000" ;
     skos:prefLabel "Jüdisches Kulturleben"@de .
 
-:s637000
+:N637000
     a skos:Concept ;
-    skos:broader :s630000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N630000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "637000" ;
     skos:prefLabel "Sprache und Literatur der Juden"@de .
 
-:s638000
+:N638000
     a skos:Concept ;
-    skos:broader :s630000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N630000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "638000" ;
     skos:prefLabel "Jüdisches Bildungswesen"@de .
 
-:s650000
+:N650000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s6 ;
-    skos:narrower :s650100, :s651000, :s655000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N6 ;
+    skos:narrower :N650100, :N651000, :N655000 ;
     skos:notation "650000" ;
     skos:prefLabel "Nichtchristliche Religionen. Weltanschauungen"@de .
 
-:s650100
+:N650100
     a skos:Concept ;
-    skos:broader :s650000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N650000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "650100" ;
     skos:prefLabel "Nichtchristliche Religionen. Weltanschauungen - Allgemeines"@de .
 
-:s651000
+:N651000
     a skos:Concept ;
-    skos:broader :s650000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s651020, :s651030 ;
+    skos:broader :N650000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N651020, :N651030 ;
     skos:notation "651000" ;
     skos:prefLabel "Nichtchristliche Religionen"@de .
 
-:s651020
+:N651020
     a skos:Concept ;
-    skos:broader :s651000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N651000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "651020" ;
     skos:prefLabel "Islam"@de .
 
-:s651030
+:N651030
     a skos:Concept ;
-    skos:broader :s651000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N651000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "651030" ;
     skos:prefLabel "Buddhismus"@de .
 
-:s655000
+:N655000
     a skos:Concept ;
-    skos:broader :s650000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s655030 ;
+    skos:broader :N650000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N655030 ;
     skos:notation "655000" ;
     skos:prefLabel "Weltanschauungen"@de .
 
-:s655030
+:N655030
     a skos:Concept ;
-    skos:broader :s655000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N655000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "655030" ;
     skos:prefLabel "Freimaurer"@de .
 
-:s700000
+:N700000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s7 ;
-    skos:narrower :s700100, :s702000, :s704000, :s704200, :s704400, :s704600, :s706000, :s706200, :s708000, :s708200, :s708400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N7 ;
+    skos:narrower :N700100, :N702000, :N704000, :N704200, :N704400, :N704600, :N706000, :N706200, :N708000, :N708200, :N708400 ;
     skos:notation "700000" ;
     skos:prefLabel "Volkskunde"@de .
 
-:s700100
+:N700100
     a skos:Concept ;
-    skos:broader :s700000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N700000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "700100" ;
     skos:prefLabel "Volkskunde - Allgemeines"@de .
 
-:s702000
+:N702000
     a skos:Concept ;
-    skos:broader :s700000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N700000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "702000" ;
     skos:prefLabel "Alltag"@de .
 
-:s704000
+:N704000
     a skos:Concept ;
-    skos:broader :s700000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s704020, :s704040, :s704060, :s704070, :s704080, :s704090 ;
+    skos:broader :N700000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N704020, :N704040, :N704060, :N704070, :N704080, :N704090 ;
     skos:notation "704000" ;
     skos:prefLabel "Brauchtum"@de .
 
-:s704020
+:N704020
     a skos:Concept ;
-    skos:broader :s704000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704020" ;
     skos:prefLabel "Brauchtum im Alltag"@de .
 
-:s704040
+:N704040
     a skos:Concept ;
-    skos:broader :s704000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s704042, :s704043, :s704044, :s704045, :s704046, :s704047 ;
+    skos:broader :N704000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N704042, :N704043, :N704044, :N704045, :N704046, :N704047 ;
     skos:notation "704040" ;
     skos:prefLabel "Brauchtum im Jahreslauf"@de .
 
-:s704042
+:N704042
     a skos:Concept ;
-    skos:broader :s704040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704042" ;
     skos:prefLabel "Winter. Weihnachten. Neujahr"@de .
 
-:s704043
+:N704043
     a skos:Concept ;
-    skos:broader :s704040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704043" ;
     skos:prefLabel "Fastnacht. Karneval"@de .
 
-:s704044
+:N704044
     a skos:Concept ;
-    skos:broader :s704040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704044" ;
     skos:prefLabel "Frühling. Ostern"@de .
 
-:s704045
+:N704045
     a skos:Concept ;
-    skos:broader :s704040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704045" ;
     skos:prefLabel "Mai. Pfingsten. Sommer"@de .
 
-:s704046
+:N704046
     a skos:Concept ;
-    skos:broader :s704040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704046" ;
     skos:prefLabel "Herbst. Erntebräuche"@de .
 
-:s704047
+:N704047
     a skos:Concept ;
-    skos:broader :s704040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704047" ;
     skos:prefLabel "Kirchweih"@de .
 
-:s704060
+:N704060
     a skos:Concept ;
-    skos:broader :s704000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s704063, :s704064 ;
+    skos:broader :N704000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N704063, :N704064 ;
     skos:notation "704060" ;
     skos:prefLabel "Brauchtum im Lebenslauf"@de .
 
-:s704063
+:N704063
     a skos:Concept ;
-    skos:broader :s704060 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704060 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704063" ;
     skos:prefLabel "Liebe. Verlobung. Hochzeit"@de .
 
-:s704064
+:N704064
     a skos:Concept ;
-    skos:broader :s704060 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704060 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704064" ;
     skos:prefLabel "Tod. Bestattung"@de .
 
-:s704070
+:N704070
     a skos:Concept ;
-    skos:broader :s704000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704070" ;
     skos:prefLabel "Schützenwesen"@de .
 
-:s704080
+:N704080
     a skos:Concept ;
-    skos:broader :s704000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s704082 ;
+    skos:broader :N704000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N704082 ;
     skos:notation "704080" ;
     skos:prefLabel "Brauchtum der Berufe"@de .
 
-:s704082
+:N704082
     a skos:Concept ;
-    skos:broader :s704080 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704080 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704082" ;
     skos:prefLabel "Handwerksbräuche"@de .
 
-:s704090
+:N704090
     a skos:Concept ;
-    skos:broader :s704000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704090" ;
     skos:prefLabel "Vereine der Brauchtumspflege"@de .
 
-:s704200
+:N704200
     a skos:Concept ;
-    skos:broader :s700000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s704220, :s704250, :s704260, :s704270, :s704280 ;
+    skos:broader :N700000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N704220, :N704250, :N704260, :N704270, :N704280 ;
     skos:notation "704200" ;
     skos:prefLabel "Volkswissen. Volksglaube"@de .
 
-:s704220
+:N704220
     a skos:Concept ;
-    skos:broader :s704200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704220" ;
     skos:prefLabel "Volksmedizin"@de .
 
-:s704250
+:N704250
     a skos:Concept ;
-    skos:broader :s704200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704250" ;
     skos:prefLabel "Wetter"@de .
 
-:s704260
+:N704260
     a skos:Concept ;
-    skos:broader :s704200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704260" ;
     skos:prefLabel "Astrologie"@de .
 
-:s704270
+:N704270
     a skos:Concept ;
-    skos:broader :s704200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704270" ;
     skos:prefLabel "Wahrsagen"@de .
 
-:s704280
+:N704280
     a skos:Concept ;
-    skos:broader :s704200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704280" ;
     skos:prefLabel "Alchemie"@de .
 
-:s704400
+:N704400
     a skos:Concept ;
-    skos:broader :s700000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N700000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704400" ;
     skos:prefLabel "Rechtliche Volkskunde"@de .
 
-:s704600
+:N704600
     a skos:Concept ;
-    skos:broader :s700000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s704620 ;
+    skos:broader :N700000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N704620 ;
     skos:notation "704600" ;
     skos:prefLabel "Religiöse Volkskunde"@de .
 
-:s704620
+:N704620
     a skos:Concept ;
-    skos:broader :s704600 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s704624, :s704626 ;
+    skos:broader :N704600 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N704624, :N704626 ;
     skos:notation "704620" ;
     skos:prefLabel "Volksfrömmigkeit"@de .
 
-:s704624
+:N704624
     a skos:Concept ;
-    skos:broader :s704620 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704620 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704624" ;
     skos:prefLabel "Gegenstände der Frömmigkeit"@de .
 
-:s704626
+:N704626
     a skos:Concept ;
-    skos:broader :s704620 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N704620 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "704626" ;
     skos:prefLabel "Volkstümliche Heiligenverehrung"@de .
 
-:s706000
+:N706000
     a skos:Concept ;
-    skos:broader :s700000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s706020, :s706030, :s706040, :s706050, :s706060, :s706070, :s706080, :s706090 ;
+    skos:broader :N700000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N706020, :N706030, :N706040, :N706050, :N706060, :N706070, :N706080, :N706090 ;
     skos:notation "706000" ;
     skos:prefLabel "Volksliteratur"@de .
 
-:s706020
+:N706020
     a skos:Concept ;
-    skos:broader :s706000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706020" ;
     skos:prefLabel "Volksbücher"@de .
 
-:s706030
+:N706030
     a skos:Concept ;
-    skos:broader :s706000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706030" ;
     skos:prefLabel "Volkserzählungen"@de .
 
-:s706040
+:N706040
     a skos:Concept ;
-    skos:broader :s706000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s706041, :s706042, :s706043 ;
+    skos:broader :N706000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N706041, :N706042, :N706043 ;
     skos:notation "706040" ;
     skos:prefLabel "Märchen. Sagen. Legenden"@de .
 
-:s706041
+:N706041
     a skos:Concept ;
-    skos:broader :s706040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706041" ;
     skos:prefLabel "Märchen"@de .
 
-:s706042
+:N706042
     a skos:Concept ;
-    skos:broader :s706040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706042" ;
     skos:prefLabel "Sagen"@de .
 
-:s706043
+:N706043
     a skos:Concept ;
-    skos:broader :s706040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706043" ;
     skos:prefLabel "Legenden"@de .
 
-:s706050
+:N706050
     a skos:Concept ;
-    skos:broader :s706000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s706052 ;
+    skos:broader :N706000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N706052 ;
     skos:notation "706050" ;
     skos:prefLabel "Schwänke"@de .
 
-:s706052
+:N706052
     a skos:Concept ;
-    skos:broader :s706050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706052" ;
     skos:prefLabel "Witz"@de .
 
-:s706060
+:N706060
     a skos:Concept ;
-    skos:broader :s706000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706060" ;
     skos:prefLabel "Sprichwörter"@de .
 
-:s706070
+:N706070
     a skos:Concept ;
-    skos:broader :s706000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706070" ;
     skos:prefLabel "Inschriften"@de .
 
-:s706080
+:N706080
     a skos:Concept ;
-    skos:broader :s706000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706080" ;
     skos:prefLabel "Rätsel"@de .
 
-:s706090
+:N706090
     a skos:Concept ;
-    skos:broader :s706000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706090" ;
     skos:prefLabel "Mundartliteratur"@de .
 
-:s706200
+:N706200
     a skos:Concept ;
-    skos:broader :s700000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s706210, :s706220, :s706230, :s706240 ;
+    skos:broader :N700000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N706210, :N706220, :N706230, :N706240 ;
     skos:notation "706200" ;
     skos:prefLabel "Volksmusik und Volkstanz"@de .
 
-:s706210
+:N706210
     a skos:Concept ;
-    skos:broader :s706200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706210" ;
     skos:prefLabel "Volksmusik"@de .
 
-:s706220
+:N706220
     a skos:Concept ;
-    skos:broader :s706200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706220" ;
     skos:prefLabel "Musikinstrumente"@de .
 
-:s706230
+:N706230
     a skos:Concept ;
-    skos:broader :s706200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706230" ;
     skos:prefLabel "Volkslied"@de .
 
-:s706240
+:N706240
     a skos:Concept ;
-    skos:broader :s706200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N706200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "706240" ;
     skos:prefLabel "Volkstanz"@de .
 
-:s708000
+:N708000
     a skos:Concept ;
-    skos:broader :s700000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s708020, :s708030, :s708040, :s708050, :s708060 ;
+    skos:broader :N700000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N708020, :N708030, :N708040, :N708050, :N708060 ;
     skos:notation "708000" ;
     skos:prefLabel "Sachkulturforschung"@de .
 
-:s708020
+:N708020
     a skos:Concept ;
-    skos:broader :s708000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s708024, :s708028, :s708029 ;
+    skos:broader :N708000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N708024, :N708028, :N708029 ;
     skos:notation "708020" ;
     skos:prefLabel "Hausformen"@de .
 
-:s708024
+:N708024
     a skos:Concept ;
-    skos:broader :s708020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708024" ;
     skos:prefLabel "Bürgerhäuser"@de .
 
-:s708028
+:N708028
     a skos:Concept ;
-    skos:broader :s708020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708028" ;
     skos:prefLabel "Bauernhäuser"@de .
 
-:s708029
+:N708029
     a skos:Concept ;
-    skos:broader :s708020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708029" ;
     skos:prefLabel "Sonstige Landwirtschaftliche Gebäude. Mühlen"@de .
 
-:s708030
+:N708030
     a skos:Concept ;
-    skos:broader :s708000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708030" ;
     skos:prefLabel "Hausrat"@de .
 
-:s708040
+:N708040
     a skos:Concept ;
-    skos:broader :s708000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708040" ;
     skos:prefLabel "Geräte"@de .
 
-:s708050
+:N708050
     a skos:Concept ;
-    skos:broader :s708000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708050" ;
     skos:prefLabel "Spielzeug. Spiele"@de .
 
-:s708060
+:N708060
     a skos:Concept ;
-    skos:broader :s708000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708060" ;
     skos:prefLabel "Nahrung"@de .
 
-:s708200
+:N708200
     a skos:Concept ;
-    skos:broader :s700000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s708220, :s708230, :s708250, :s708260, :s708270, :s708280, :s708290 ;
+    skos:broader :N700000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N708220, :N708230, :N708250, :N708260, :N708270, :N708280, :N708290 ;
     skos:notation "708200" ;
     skos:prefLabel "Volkskunst"@de .
 
-:s708220
+:N708220
     a skos:Concept ;
-    skos:broader :s708200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708220" ;
     skos:prefLabel "Holzbearbeitung"@de .
 
-:s708230
+:N708230
     a skos:Concept ;
-    skos:broader :s708200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708230" ;
     skos:prefLabel "Bilder. Malerei"@de .
 
-:s708250
+:N708250
     a skos:Concept ;
-    skos:broader :s708200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708250" ;
     skos:prefLabel "Keramik"@de .
 
-:s708260
+:N708260
     a skos:Concept ;
-    skos:broader :s708200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708260" ;
     skos:prefLabel "Steinbearbeitung"@de .
 
-:s708270
+:N708270
     a skos:Concept ;
-    skos:broader :s708200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708270" ;
     skos:prefLabel "Metallbearbeitung"@de .
 
-:s708280
+:N708280
     a skos:Concept ;
-    skos:broader :s708200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708280" ;
     skos:prefLabel "Glas"@de .
 
-:s708290
+:N708290
     a skos:Concept ;
-    skos:broader :s708200 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708290" ;
     skos:prefLabel "Textilien"@de .
 
-:s708400
+:N708400
     a skos:Concept ;
-    skos:broader :s700000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s708410, :s708430, :s708450 ;
+    skos:broader :N700000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N708410, :N708430, :N708450 ;
     skos:notation "708400" ;
     skos:prefLabel "Kleidung. Schmuck"@de .
 
-:s708410
+:N708410
     a skos:Concept ;
-    skos:broader :s708400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708410" ;
     skos:prefLabel "Kleidung"@de .
 
-:s708430
+:N708430
     a skos:Concept ;
-    skos:broader :s708400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708430" ;
     skos:prefLabel "Tracht"@de .
 
-:s708450
+:N708450
     a skos:Concept ;
-    skos:broader :s708400 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N708400 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "708450" ;
     skos:prefLabel "Schmuck"@de .
 
-:s720000
+:N720000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s7 ;
-    skos:narrower :s720100, :s722000, :s723000, :s724000, :s725000, :s726000, :s729000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N7 ;
+    skos:narrower :N720100, :N722000, :N723000, :N724000, :N725000, :N726000, :N729000 ;
     skos:notation "720000" ;
     skos:prefLabel "Gesellschaft"@de .
 
-:s720100
+:N720100
     a skos:Concept ;
-    skos:broader :s720000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N720000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "720100" ;
     skos:prefLabel "Gesellschaft - Allgemeines"@de .
 
-:s722000
+:N722000
     a skos:Concept ;
-    skos:broader :s720000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N720000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "722000" ;
     skos:prefLabel "Sozialgeschichte"@de .
 
-:s723000
+:N723000
     a skos:Concept ;
-    skos:broader :s720000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N720000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "723000" ;
     skos:prefLabel "Soziales System"@de .
 
-:s724000
+:N724000
     a skos:Concept ;
-    skos:broader :s720000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s724020, :s724030, :s724040, :s724050, :s724060, :s724070 ;
+    skos:broader :N720000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N724020, :N724030, :N724040, :N724050, :N724060, :N724070 ;
     skos:notation "724000" ;
     skos:prefLabel "Sozialstruktur"@de .
 
-:s724020
+:N724020
     a skos:Concept ;
-    skos:broader :s724000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N724000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "724020" ;
     skos:prefLabel "Kinder"@de .
 
-:s724030
+:N724030
     a skos:Concept ;
-    skos:broader :s724000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N724000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "724030" ;
     skos:prefLabel "Jugend"@de .
 
-:s724040
+:N724040
     a skos:Concept ;
-    skos:broader :s724000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N724000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "724040" ;
     skos:prefLabel "Frauen"@de .
 
-:s724050
+:N724050
     a skos:Concept ;
-    skos:broader :s724000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N724000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "724050" ;
     skos:prefLabel "Männer"@de .
 
-:s724060
+:N724060
     a skos:Concept ;
-    skos:broader :s724000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N724000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "724060" ;
     skos:prefLabel "Alter"@de .
 
-:s724070
+:N724070
     a skos:Concept ;
-    skos:broader :s724000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N724000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "724070" ;
     skos:prefLabel "Originale"@de .
 
-:s725000
+:N725000
     a skos:Concept ;
-    skos:broader :s720000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s725010, :s725020, :s725030, :s725040, :s725050, :s725060, :s725070, :s725080 ;
+    skos:broader :N720000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N725010, :N725020, :N725030, :N725040, :N725050, :N725060, :N725070, :N725080 ;
     skos:notation "725000" ;
     skos:prefLabel "Soziale Gruppen"@de .
 
-:s725010
+:N725010
     a skos:Concept ;
-    skos:broader :s725000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N725000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "725010" ;
     skos:prefLabel "Familie"@de .
 
-:s725020
+:N725020
     a skos:Concept ;
-    skos:broader :s725000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N725000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "725020" ;
     skos:prefLabel "Nachbarschaft"@de .
 
-:s725030
+:N725030
     a skos:Concept ;
-    skos:broader :s725000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N725000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "725030" ;
     skos:prefLabel "Dorfgemeinschaft"@de .
 
-:s725040
+:N725040
     a skos:Concept ;
-    skos:broader :s725000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N725000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "725040" ;
     skos:prefLabel "Alternative Lebensformen"@de .
 
-:s725050
+:N725050
     a skos:Concept ;
-    skos:broader :s725000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N725000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "725050" ;
     skos:prefLabel "Vereine. Interessenverbände"@de .
 
-:s725060
+:N725060
     a skos:Concept ;
-    skos:broader :s725000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N725000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "725060" ;
     skos:prefLabel "Minderheiten. Randgruppen"@de .
 
-:s725070
+:N725070
     a skos:Concept ;
-    skos:broader :s725000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N725000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "725070" ;
     skos:prefLabel "Ausländer"@de .
 
-:s725080
+:N725080
     a skos:Concept ;
-    skos:broader :s725000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N725000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "725080" ;
     skos:prefLabel "Behinderte"@de .
 
-:s726000
+:N726000
     a skos:Concept ;
-    skos:broader :s720000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N720000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "726000" ;
     skos:prefLabel "Sozialer Wandel"@de .
 
-:s729000
+:N729000
     a skos:Concept ;
-    skos:broader :s720000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N720000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "729000" ;
     skos:prefLabel "Sexualität"@de .
 
-:s730000
+:N730000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s7 ;
-    skos:narrower :s730100, :s731000, :s732000, :s733000, :s734000, :s735000, :s736000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N7 ;
+    skos:narrower :N730100, :N731000, :N732000, :N733000, :N734000, :N735000, :N736000 ;
     skos:notation "730000" ;
     skos:prefLabel "Kultur und Freizeit"@de .
 
-:s730100
+:N730100
     a skos:Concept ;
-    skos:broader :s730000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N730000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "730100" ;
     skos:prefLabel "Kultur und Freizeit - Allgemeines"@de .
 
-:s731000
+:N731000
     a skos:Concept ;
-    skos:broader :s730000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N730000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "731000" ;
     skos:prefLabel "Kulturpolitik"@de .
 
-:s732000
+:N732000
     a skos:Concept ;
-    skos:broader :s730000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N730000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "732000" ;
     skos:prefLabel "Kulturgeschichte"@de .
 
-:s733000
+:N733000
     a skos:Concept ;
-    skos:broader :s730000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s733030, :s733050 ;
+    skos:broader :N730000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N733030, :N733050 ;
     skos:notation "733000" ;
     skos:prefLabel "Zeitgenössisches Kulturleben"@de .
 
-:s733030
+:N733030
     a skos:Concept ;
-    skos:broader :s733000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N733000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "733030" ;
     skos:prefLabel "Kulturveranstaltungen"@de .
 
-:s733050
+:N733050
     a skos:Concept ;
-    skos:broader :s733000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N733000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "733050" ;
     skos:prefLabel "Kulturpreise"@de .
 
-:s734000
+:N734000
     a skos:Concept ;
-    skos:broader :s730000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N730000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "734000" ;
     skos:prefLabel "Feiern und Feste"@de .
 
-:s735000
+:N735000
     a skos:Concept ;
-    skos:broader :s730000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s735020, :s735040, :s735090 ;
+    skos:broader :N730000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N735020, :N735040, :N735090 ;
     skos:notation "735000" ;
     skos:prefLabel "Freizeit und Erholung"@de .
 
-:s735020
+:N735020
     a skos:Concept ;
-    skos:broader :s735000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N735000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "735020" ;
     skos:prefLabel "Freizeiteinrichtungen"@de .
 
-:s735040
+:N735040
     a skos:Concept ;
-    skos:broader :s735000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N735000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "735040" ;
     skos:prefLabel "Freizeitgestaltung"@de .
 
-:s735090
+:N735090
     a skos:Concept ;
-    skos:broader :s735000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N735000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "735090" ;
     skos:prefLabel "Freizeitvereine"@de .
 
-:s736000
+:N736000
     a skos:Concept ;
-    skos:broader :s730000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s736030, :s736050 ;
+    skos:broader :N730000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N736030, :N736050 ;
     skos:notation "736000" ;
     skos:prefLabel "Sport und Spiel"@de .
 
-:s736030
+:N736030
     a skos:Concept ;
-    skos:broader :s736000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N736000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "736030" ;
     skos:prefLabel "Einzelne Sportarten"@de .
 
-:s736050
+:N736050
     a skos:Concept ;
-    skos:broader :s736000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N736000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "736050" ;
     skos:prefLabel "Sportvereine"@de .
 
-:s740000
+:N740000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s7 ;
-    skos:narrower :s740100, :s742000, :s744000, :s745000, :s746000, :s747000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N7 ;
+    skos:narrower :N740100, :N742000, :N744000, :N745000, :N746000, :N747000 ;
     skos:notation "740000" ;
     skos:prefLabel "Sprache"@de .
 
-:s740100
+:N740100
     a skos:Concept ;
-    skos:broader :s740000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N740000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "740100" ;
     skos:prefLabel "Sprache - Allgemeines"@de .
 
-:s742000
+:N742000
     a skos:Concept ;
-    skos:broader :s740000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N740000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "742000" ;
     skos:prefLabel "Sprachgeschichte"@de .
 
-:s744000
+:N744000
     a skos:Concept ;
-    skos:broader :s740000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N740000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "744000" ;
     skos:prefLabel "Mundarten"@de .
 
-:s745000
+:N745000
     a skos:Concept ;
-    skos:broader :s740000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N740000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "745000" ;
     skos:prefLabel "Sprachgeographie"@de .
 
-:s746000
+:N746000
     a skos:Concept ;
-    skos:broader :s740000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s746020, :s746030, :s746040, :s746050, :s746060 ;
+    skos:broader :N740000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N746020, :N746030, :N746040, :N746050, :N746060 ;
     skos:notation "746000" ;
     skos:prefLabel "Namenkunde"@de .
 
-:s746020
+:N746020
     a skos:Concept ;
-    skos:broader :s746000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N746000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "746020" ;
     skos:prefLabel "Personennamen"@de .
 
-:s746030
+:N746030
     a skos:Concept ;
-    skos:broader :s746000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s746032, :s746034 ;
+    skos:broader :N746000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N746032, :N746034 ;
     skos:notation "746030" ;
     skos:prefLabel "Hausnamen. Hofnamen"@de .
 
-:s746032
+:N746032
     a skos:Concept ;
-    skos:broader :s746030 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N746030 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "746032" ;
     skos:prefLabel "Hausnamen"@de .
 
-:s746034
+:N746034
     a skos:Concept ;
-    skos:broader :s746030 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N746030 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "746034" ;
     skos:prefLabel "Hofnamen"@de .
 
-:s746040
+:N746040
     a skos:Concept ;
-    skos:broader :s746000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s746042, :s746043, :s746044, :s746045, :s746046 ;
+    skos:broader :N746000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N746042, :N746043, :N746044, :N746045, :N746046 ;
     skos:notation "746040" ;
     skos:prefLabel "Geographische Namen"@de .
 
-:s746042
+:N746042
     a skos:Concept ;
-    skos:broader :s746040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N746040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "746042" ;
     skos:prefLabel "Ortsnamen"@de .
 
-:s746043
+:N746043
     a skos:Concept ;
-    skos:broader :s746040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N746040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "746043" ;
     skos:prefLabel "Straßennamen"@de .
 
-:s746044
+:N746044
     a skos:Concept ;
-    skos:broader :s746040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N746040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "746044" ;
     skos:prefLabel "Flurnamen"@de .
 
-:s746045
+:N746045
     a skos:Concept ;
-    skos:broader :s746040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N746040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "746045" ;
     skos:prefLabel "Bergnamen"@de .
 
-:s746046
+:N746046
     a skos:Concept ;
-    skos:broader :s746040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N746040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "746046" ;
     skos:prefLabel "Gewässernamen"@de .
 
-:s746050
+:N746050
     a skos:Concept ;
-    skos:broader :s746000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N746000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "746050" ;
     skos:prefLabel "Tiernamen"@de .
 
-:s746060
+:N746060
     a skos:Concept ;
-    skos:broader :s746000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N746000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "746060" ;
     skos:prefLabel "Pflanzennamen"@de .
 
-:s747000
+:N747000
     a skos:Concept ;
-    skos:broader :s740000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s747010, :s747020, :s747030, :s747060 ;
+    skos:broader :N740000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N747010, :N747020, :N747030, :N747060 ;
     skos:notation "747000" ;
     skos:prefLabel "Soziolinguistik"@de .
 
-:s747010
+:N747010
     a skos:Concept ;
-    skos:broader :s747000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N747000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "747010" ;
     skos:prefLabel "Umgangssprache"@de .
 
-:s747020
+:N747020
     a skos:Concept ;
-    skos:broader :s747000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N747000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "747020" ;
     skos:prefLabel "Geheimsprachen"@de .
 
-:s747030
+:N747030
     a skos:Concept ;
-    skos:broader :s747000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N747000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "747030" ;
     skos:prefLabel "Fachsprachen"@de .
 
-:s747060
+:N747060
     a skos:Concept ;
-    skos:broader :s747000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N747000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "747060" ;
     skos:prefLabel "Sprachpflege"@de .
 
-:s760000
+:N760000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s7 ;
-    skos:narrower :s760100, :s761000, :s762000, :s766000, :s767000, :s768000, :s769000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N7 ;
+    skos:narrower :N760100, :N761000, :N762000, :N766000, :N767000, :N768000, :N769000 ;
     skos:notation "760000" ;
     skos:prefLabel "Literatur"@de .
 
-:s760100
+:N760100
     a skos:Concept ;
-    skos:broader :s760000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N760000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "760100" ;
     skos:prefLabel "Literatur - Allgemeines"@de .
 
-:s761000
+:N761000
     a skos:Concept ;
-    skos:broader :s760000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s761020, :s761050 ;
+    skos:broader :N760000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N761020, :N761050 ;
     skos:notation "761000" ;
     skos:prefLabel "Literaturwissenschaft"@de .
 
-:s761020
+:N761020
     a skos:Concept ;
-    skos:broader :s761000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N761000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "761020" ;
     skos:prefLabel "Regionalliteratur"@de .
 
-:s761050
+:N761050
     a skos:Concept ;
-    skos:broader :s761000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N761000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "761050" ;
     skos:prefLabel "Stoff-, Motiv- und Themenforschung"@de .
 
-:s762000
+:N762000
     a skos:Concept ;
-    skos:broader :s760000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N760000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "762000" ;
     skos:prefLabel "Literaturgeschichte"@de .
 
-:s766000
+:N766000
     a skos:Concept ;
-    skos:broader :s760000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s766030, :s766050, :s766060 ;
+    skos:broader :N760000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N766030, :N766050, :N766060 ;
     skos:notation "766000" ;
     skos:prefLabel "Literatursoziologie"@de .
 
-:s766030
+:N766030
     a skos:Concept ;
-    skos:broader :s766000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N766000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "766030" ;
     skos:prefLabel "Leser"@de .
 
-:s766050
+:N766050
     a skos:Concept ;
-    skos:broader :s766000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s766051, :s766052 ;
+    skos:broader :N766000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N766051, :N766052 ;
     skos:notation "766050" ;
     skos:prefLabel "Literaturförderung"@de .
 
-:s766051
+:N766051
     a skos:Concept ;
-    skos:broader :s766050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N766050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "766051" ;
     skos:prefLabel "Literaturpreise"@de .
 
-:s766052
+:N766052
     a skos:Concept ;
-    skos:broader :s766050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N766050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "766052" ;
     skos:prefLabel "Literaturwettbewerbe"@de .
 
-:s766060
+:N766060
     a skos:Concept ;
-    skos:broader :s766000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N766000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "766060" ;
     skos:prefLabel "Literaturausstellungen"@de .
 
-:s767000
+:N767000
     a skos:Concept ;
-    skos:broader :s760000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s767040 ;
+    skos:broader :N760000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N767040 ;
     skos:notation "767000" ;
     skos:prefLabel "Literarische Texte"@de .
 
-:s767040
+:N767040
     a skos:Concept ;
-    skos:broader :s767000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N767000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "767040" ;
     skos:prefLabel "Anthologien"@de .
 
-:s768000
+:N768000
     a skos:Concept ;
-    skos:broader :s760000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s768010, :s768030 ;
+    skos:broader :N760000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N768010, :N768030 ;
     skos:notation "768000" ;
     skos:prefLabel "Schriftsteller"@de .
 
-:s768010
+:N768010
     a skos:Concept ;
-    skos:broader :s768000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N768000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "768010" ;
     skos:prefLabel "Einzelne Autoren (Primärliteratur)"@de .
 
-:s768030
+:N768030
     a skos:Concept ;
-    skos:broader :s768000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N768000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "768030" ;
     skos:prefLabel "Einzelne Autoren (Sekundärliteratur)"@de .
 
-:s769000
+:N769000
     a skos:Concept ;
-    skos:broader :s760000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s769020, :s769030, :s769040, :s769050 ;
+    skos:broader :N760000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N769020, :N769030, :N769040, :N769050 ;
     skos:notation "769000" ;
     skos:prefLabel "Literaturgattungen"@de .
 
-:s769020
+:N769020
     a skos:Concept ;
-    skos:broader :s769000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N769000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "769020" ;
     skos:prefLabel "Lyrik"@de .
 
-:s769030
+:N769030
     a skos:Concept ;
-    skos:broader :s769000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N769000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "769030" ;
     skos:prefLabel "Drama"@de .
 
-:s769040
+:N769040
     a skos:Concept ;
-    skos:broader :s769000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N769000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "769040" ;
     skos:prefLabel "Epik"@de .
 
-:s769050
+:N769050
     a skos:Concept ;
-    skos:broader :s769000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N769000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "769050" ;
     skos:prefLabel "Kurzepik"@de .
 
-:s780000
+:N780000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s7 ;
-    skos:narrower :s780100, :s781000, :s782000, :s782500, :s783000, :s784000, :s785000, :s785500, :s786000, :s788000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N7 ;
+    skos:narrower :N780100, :N781000, :N782000, :N782500, :N783000, :N784000, :N785000, :N785500, :N786000, :N788000 ;
     skos:notation "780000" ;
     skos:prefLabel "Bildung und Erziehung"@de .
 
-:s780100
+:N780100
     a skos:Concept ;
-    skos:broader :s780000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N780000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "780100" ;
     skos:prefLabel "Bildung und Erziehung - Allgemeines"@de .
 
-:s781000
+:N781000
     a skos:Concept ;
-    skos:broader :s780000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N780000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "781000" ;
     skos:prefLabel "Bildungspolitik"@de .
 
-:s782000
+:N782000
     a skos:Concept ;
-    skos:broader :s780000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N780000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "782000" ;
     skos:prefLabel "Erziehung"@de .
 
-:s782500
+:N782500
     a skos:Concept ;
-    skos:broader :s780000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N780000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "782500" ;
     skos:prefLabel "Vorschulerziehung"@de .
 
-:s783000
+:N783000
     a skos:Concept ;
-    skos:broader :s780000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N780000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "783000" ;
     skos:prefLabel "Schulgeschichte"@de .
 
-:s784000
+:N784000
     a skos:Concept ;
-    skos:broader :s780000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s784010, :s784020, :s784030, :s784040, :s784050, :s784060, :s784070, :s784080, :s784090 ;
+    skos:broader :N780000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N784010, :N784020, :N784030, :N784040, :N784050, :N784060, :N784070, :N784080, :N784090 ;
     skos:notation "784000" ;
     skos:prefLabel "Allgemeinbildende Schulen"@de .
 
-:s784010
+:N784010
     a skos:Concept ;
-    skos:broader :s784000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s784012, :s784014 ;
+    skos:broader :N784000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N784012, :N784014 ;
     skos:notation "784010" ;
     skos:prefLabel "Schulpolitik"@de .
 
-:s784012
+:N784012
     a skos:Concept ;
-    skos:broader :s784010 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784010 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784012" ;
     skos:prefLabel "Schulreformen"@de .
 
-:s784014
+:N784014
     a skos:Concept ;
-    skos:broader :s784010 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784010 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784014" ;
     skos:prefLabel "Schulversuche"@de .
 
-:s784020
+:N784020
     a skos:Concept ;
-    skos:broader :s784000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s784025 ;
+    skos:broader :N784000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N784025 ;
     skos:notation "784020" ;
     skos:prefLabel "Schulrecht"@de .
 
-:s784025
+:N784025
     a skos:Concept ;
-    skos:broader :s784020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784025" ;
     skos:prefLabel "Elternvertretung"@de .
 
-:s784030
+:N784030
     a skos:Concept ;
-    skos:broader :s784000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784030" ;
     skos:prefLabel "Schulverwaltung"@de .
 
-:s784040
+:N784040
     a skos:Concept ;
-    skos:broader :s784000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s784041, :s784042, :s784043, :s784044, :s784045, :s784046, :s784048, :s784049 ;
+    skos:broader :N784000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N784041, :N784042, :N784043, :N784044, :N784045, :N784046, :N784048, :N784049 ;
     skos:notation "784040" ;
     skos:prefLabel "Schulformen"@de .
 
-:s784041
+:N784041
     a skos:Concept ;
-    skos:broader :s784040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784041" ;
     skos:prefLabel "Grundschulen"@de .
 
-:s784042
+:N784042
     a skos:Concept ;
-    skos:broader :s784040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784042" ;
     skos:prefLabel "Hauptschulen"@de .
 
-:s784043
+:N784043
     a skos:Concept ;
-    skos:broader :s784040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784043" ;
     skos:prefLabel "Realschulen"@de .
 
-:s784044
+:N784044
     a skos:Concept ;
-    skos:broader :s784040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784044" ;
     skos:prefLabel "Gymnasien"@de .
 
-:s784045
+:N784045
     a skos:Concept ;
-    skos:broader :s784040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784045" ;
     skos:prefLabel "Gesamtschulen"@de .
 
-:s784046
+:N784046
     a skos:Concept ;
-    skos:broader :s784040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784046" ;
     skos:prefLabel "Kollegschulen"@de .
 
-:s784048
+:N784048
     a skos:Concept ;
-    skos:broader :s784040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784048" ;
     skos:prefLabel "Sonderschulen"@de .
 
-:s784049
+:N784049
     a skos:Concept ;
-    skos:broader :s784040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784049" ;
     skos:prefLabel "Privatschulen"@de .
 
-:s784050
+:N784050
     a skos:Concept ;
-    skos:broader :s784000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s784051, :s784052, :s784053, :s784054 ;
+    skos:broader :N784000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N784051, :N784052, :N784053, :N784054 ;
     skos:notation "784050" ;
     skos:prefLabel "Schulstufen"@de .
 
-:s784051
+:N784051
     a skos:Concept ;
-    skos:broader :s784050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784051" ;
     skos:prefLabel "Elementarbereich"@de .
 
-:s784052
+:N784052
     a skos:Concept ;
-    skos:broader :s784050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784052" ;
     skos:prefLabel "Primarstufe"@de .
 
-:s784053
+:N784053
     a skos:Concept ;
-    skos:broader :s784050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784053" ;
     skos:prefLabel "Sekundarstufe 1"@de .
 
-:s784054
+:N784054
     a skos:Concept ;
-    skos:broader :s784050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784054" ;
     skos:prefLabel "Sekundarstufe 2"@de .
 
-:s784060
+:N784060
     a skos:Concept ;
-    skos:broader :s784000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s784062, :s784064, :s784066 ;
+    skos:broader :N784000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N784062, :N784064, :N784066 ;
     skos:notation "784060" ;
     skos:prefLabel "Lehrer. Pädagogen"@de .
 
-:s784062
+:N784062
     a skos:Concept ;
-    skos:broader :s784060 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784060 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784062" ;
     skos:prefLabel "Lehrerbildung"@de .
 
-:s784064
+:N784064
     a skos:Concept ;
-    skos:broader :s784060 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784060 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784064" ;
     skos:prefLabel "Lehrerfortbildung"@de .
 
-:s784066
+:N784066
     a skos:Concept ;
-    skos:broader :s784060 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784060 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784066" ;
     skos:prefLabel "Lehrerbesoldung"@de .
 
-:s784070
+:N784070
     a skos:Concept ;
-    skos:broader :s784000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s784072, :s784074, :s784078 ;
+    skos:broader :N784000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N784072, :N784074, :N784078 ;
     skos:notation "784070" ;
     skos:prefLabel "Schüler"@de .
 
-:s784072
+:N784072
     a skos:Concept ;
-    skos:broader :s784070 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784070 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784072" ;
     skos:prefLabel "Schülermitverwaltung"@de .
 
-:s784074
+:N784074
     a skos:Concept ;
-    skos:broader :s784070 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784070 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784074" ;
     skos:prefLabel "Schülertransport"@de .
 
-:s784078
+:N784078
     a skos:Concept ;
-    skos:broader :s784070 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784070 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784078" ;
     skos:prefLabel "Schüleraustausch"@de .
 
-:s784080
+:N784080
     a skos:Concept ;
-    skos:broader :s784000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784080" ;
     skos:prefLabel "Unterricht"@de .
 
-:s784090
+:N784090
     a skos:Concept ;
-    skos:broader :s784000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N784000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "784090" ;
     skos:prefLabel "Schulleben"@de .
 
-:s785000
+:N785000
     a skos:Concept ;
-    skos:broader :s780000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s785020, :s785030, :s785040, :s785050, :s785060, :s785070 ;
+    skos:broader :N780000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N785020, :N785030, :N785040, :N785050, :N785060, :N785070 ;
     skos:notation "785000" ;
     skos:prefLabel "Berufsbildende Schulen"@de .
 
-:s785020
+:N785020
     a skos:Concept ;
-    skos:broader :s785000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N785000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "785020" ;
     skos:prefLabel "Berufsschulen"@de .
 
-:s785030
+:N785030
     a skos:Concept ;
-    skos:broader :s785000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N785000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "785030" ;
     skos:prefLabel "Berufsaufbauschulen"@de .
 
-:s785040
+:N785040
     a skos:Concept ;
-    skos:broader :s785000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N785000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "785040" ;
     skos:prefLabel "Berufsfachschulen"@de .
 
-:s785050
+:N785050
     a skos:Concept ;
-    skos:broader :s785000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N785000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "785050" ;
     skos:prefLabel "Fachoberschulen"@de .
 
-:s785060
+:N785060
     a skos:Concept ;
-    skos:broader :s785000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N785000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "785060" ;
     skos:prefLabel "Fachschulen"@de .
 
-:s785070
+:N785070
     a skos:Concept ;
-    skos:broader :s785000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N785000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "785070" ;
     skos:prefLabel "Nichtstaatliche Berufsschulen"@de .
 
-:s785500
+:N785500
     a skos:Concept ;
-    skos:broader :s780000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N780000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "785500" ;
     skos:prefLabel "Berufsausbildung"@de .
 
-:s786000
+:N786000
     a skos:Concept ;
-    skos:broader :s780000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N780000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "786000" ;
     skos:prefLabel "Außerschulische Bildung"@de .
 
-:s788000
+:N788000
     a skos:Concept ;
-    skos:broader :s780000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N780000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "788000" ;
     skos:prefLabel "Erwachsenenbildung. Weiterbildung"@de .
 
-:s790000
+:N790000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s7 ;
-    skos:narrower :s790100, :s791000, :s792000, :s793000, :s794000, :s796000, :s797000, :s798000, :s798200, :s799000, :s799200 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N7 ;
+    skos:narrower :N790100, :N791000, :N792000, :N793000, :N794000, :N796000, :N797000, :N798000, :N798200, :N799000, :N799200 ;
     skos:notation "790000" ;
     skos:prefLabel "Wissenschaft und Forschung"@de .
 
-:s790100
+:N790100
     a skos:Concept ;
-    skos:broader :s790000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N790000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "790100" ;
     skos:prefLabel "Wissenschaft und Forschung - Allgemeines"@de .
 
-:s791000
+:N791000
     a skos:Concept ;
-    skos:broader :s790000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N790000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "791000" ;
     skos:prefLabel "Hochschulrecht"@de .
 
-:s792000
+:N792000
     a skos:Concept ;
-    skos:broader :s790000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N790000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "792000" ;
     skos:prefLabel "Hochschulpolitik"@de .
 
-:s793000
+:N793000
     a skos:Concept ;
-    skos:broader :s790000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N790000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "793000" ;
     skos:prefLabel "Hochschulverwaltung"@de .
 
-:s794000
+:N794000
     a skos:Concept ;
-    skos:broader :s790000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s794010 ;
+    skos:broader :N790000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N794010 ;
     skos:notation "794000" ;
     skos:prefLabel "Hochschulen"@de .
 
-:s794010
+:N794010
     a skos:Concept ;
-    skos:broader :s794000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N794000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "794010" ;
     skos:prefLabel "Einzelne Hochschulen"@de .
 
-:s796000
+:N796000
     a skos:Concept ;
-    skos:broader :s790000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N790000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "796000" ;
     skos:prefLabel "Fachhochschulen"@de .
 
-:s797000
+:N797000
     a skos:Concept ;
-    skos:broader :s790000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s797010 ;
+    skos:broader :N790000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N797010 ;
     skos:notation "797000" ;
     skos:prefLabel "Hochschullehrer. Wissenschaftler"@de .
 
-:s797010
+:N797010
     a skos:Concept ;
-    skos:broader :s797000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N797000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "797010" ;
     skos:prefLabel "Einzelne Hochschullehrer und Wissenschaftler"@de .
 
-:s798000
+:N798000
     a skos:Concept ;
-    skos:broader :s790000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N790000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "798000" ;
     skos:prefLabel "Studenten"@de .
 
-:s798200
+:N798200
     a skos:Concept ;
-    skos:broader :s790000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N790000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "798200" ;
     skos:prefLabel "Außeruniversitäre Forschung und Wissenschaft"@de .
 
-:s799000
+:N799000
     a skos:Concept ;
-    skos:broader :s790000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N790000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "799000" ;
     skos:prefLabel "Wissenschaftsförderung"@de .
 
-:s799200
+:N799200
     a skos:Concept ;
-    skos:broader :s790000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N790000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "799200" ;
     skos:prefLabel "Wissenschaftliche Gesellschaften"@de .
 
-:s800000
+:N800000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s8 ;
-    skos:narrower :s800100, :s802000, :s803000, :s804000, :s806000, :s807000, :s808000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N8 ;
+    skos:narrower :N800100, :N802000, :N803000, :N804000, :N806000, :N807000, :N808000 ;
     skos:notation "800000" ;
     skos:prefLabel "Darstellende Kunst"@de .
 
-:s800100
+:N800100
     a skos:Concept ;
-    skos:broader :s800000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N800000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "800100" ;
     skos:prefLabel "Darstellende Kunst - Allgemeines"@de .
 
-:s802000
+:N802000
     a skos:Concept ;
-    skos:broader :s800000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s802020, :s802030, :s802040, :s802050, :s802060, :s802070, :s802080 ;
+    skos:broader :N800000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N802020, :N802030, :N802040, :N802050, :N802060, :N802070, :N802080 ;
     skos:notation "802000" ;
     skos:prefLabel "Theater"@de .
 
-:s802020
+:N802020
     a skos:Concept ;
-    skos:broader :s802000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N802000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "802020" ;
     skos:prefLabel "Theatergeschichte"@de .
 
-:s802030
+:N802030
     a skos:Concept ;
-    skos:broader :s802000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N802000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "802030" ;
     skos:prefLabel "Volksschauspiel"@de .
 
-:s802040
+:N802040
     a skos:Concept ;
-    skos:broader :s802000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N802000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "802040" ;
     skos:prefLabel "Laienspiel"@de .
 
-:s802050
+:N802050
     a skos:Concept ;
-    skos:broader :s802000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N802000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "802050" ;
     skos:prefLabel "Kinder- und Jugendtheater"@de .
 
-:s802060
+:N802060
     a skos:Concept ;
-    skos:broader :s802000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N802000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "802060" ;
     skos:prefLabel "Einzelne Theater"@de .
 
-:s802070
+:N802070
     a skos:Concept ;
-    skos:broader :s802000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N802000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "802070" ;
     skos:prefLabel "Theateraufführungen"@de .
 
-:s802080
+:N802080
     a skos:Concept ;
-    skos:broader :s802000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N802000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "802080" ;
     skos:prefLabel "Schauspieler"@de .
 
-:s803000
+:N803000
     a skos:Concept ;
-    skos:broader :s800000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N800000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "803000" ;
     skos:prefLabel "Ballett"@de .
 
-:s804000
+:N804000
     a skos:Concept ;
-    skos:broader :s800000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s804020 ;
+    skos:broader :N800000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N804020 ;
     skos:notation "804000" ;
     skos:prefLabel "Film"@de .
 
-:s804020
+:N804020
     a skos:Concept ;
-    skos:broader :s804000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N804000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "804020" ;
     skos:prefLabel "Filmtheater"@de .
 
-:s806000
+:N806000
     a skos:Concept ;
-    skos:broader :s800000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s806020 ;
+    skos:broader :N800000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N806020 ;
     skos:notation "806000" ;
     skos:prefLabel "Kleinkunst"@de .
 
-:s806020
+:N806020
     a skos:Concept ;
-    skos:broader :s806000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N806000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "806020" ;
     skos:prefLabel "Kabarett"@de .
 
-:s807000
+:N807000
     a skos:Concept ;
-    skos:broader :s800000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N800000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "807000" ;
     skos:prefLabel "Figurentheater"@de .
 
-:s808000
+:N808000
     a skos:Concept ;
-    skos:broader :s800000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N800000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "808000" ;
     skos:prefLabel "Zirkus"@de .
 
-:s820000
+:N820000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s8 ;
-    skos:narrower :s820100, :s821000, :s822000, :s822400, :s822500, :s823000, :s824000, :s825000, :s825500, :s826000, :s827000, :s828000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N8 ;
+    skos:narrower :N820100, :N821000, :N822000, :N822400, :N822500, :N823000, :N824000, :N825000, :N825500, :N826000, :N827000, :N828000 ;
     skos:notation "820000" ;
     skos:prefLabel "Musik"@de .
 
-:s820100
+:N820100
     a skos:Concept ;
-    skos:broader :s820000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N820000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "820100" ;
     skos:prefLabel "Musik - Allgemeines"@de .
 
-:s821000
+:N821000
     a skos:Concept ;
-    skos:broader :s820000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N820000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "821000" ;
     skos:prefLabel "Musikwissenschaft"@de .
 
-:s822000
+:N822000
     a skos:Concept ;
-    skos:broader :s820000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N820000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "822000" ;
     skos:prefLabel "Musikerziehung"@de .
 
-:s822400
+:N822400
     a skos:Concept ;
-    skos:broader :s820000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N820000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "822400" ;
     skos:prefLabel "Musikförderung"@de .
 
-:s822500
+:N822500
     a skos:Concept ;
-    skos:broader :s820000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N820000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "822500" ;
     skos:prefLabel "Musikpreise"@de .
 
-:s823000
+:N823000
     a skos:Concept ;
-    skos:broader :s820000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N820000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "823000" ;
     skos:prefLabel "Musikgeschichte"@de .
 
-:s824000
+:N824000
     a skos:Concept ;
-    skos:broader :s820000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s824020, :s824040, :s824060 ;
+    skos:broader :N820000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N824020, :N824040, :N824060 ;
     skos:notation "824000" ;
     skos:prefLabel "Musiker"@de .
 
-:s824020
+:N824020
     a skos:Concept ;
-    skos:broader :s824000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N824000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "824020" ;
     skos:prefLabel "Sänger"@de .
 
-:s824040
+:N824040
     a skos:Concept ;
-    skos:broader :s824000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N824000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "824040" ;
     skos:prefLabel "Komponisten"@de .
 
-:s824060
+:N824060
     a skos:Concept ;
-    skos:broader :s824000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N824000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "824060" ;
     skos:prefLabel "Dirigenten"@de .
 
-:s825000
+:N825000
     a skos:Concept ;
-    skos:broader :s820000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N820000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "825000" ;
     skos:prefLabel "Orchester. Musikkapellen. Musikgruppen"@de .
 
-:s825500
+:N825500
     a skos:Concept ;
-    skos:broader :s820000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N820000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "825500" ;
     skos:prefLabel "Chöre. Gesangvereine"@de .
 
-:s826000
+:N826000
     a skos:Concept ;
-    skos:broader :s820000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N820000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "826000" ;
     skos:prefLabel "Konzerte und Musikveranstaltungen"@de .
 
-:s827000
+:N827000
     a skos:Concept ;
-    skos:broader :s820000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s827020 ;
+    skos:broader :N820000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N827020 ;
     skos:notation "827000" ;
     skos:prefLabel "Kirchenmusik"@de .
 
-:s827020
+:N827020
     a skos:Concept ;
-    skos:broader :s827000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N827000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "827020" ;
     skos:prefLabel "Kirchenmusikalische Aufführungen"@de .
 
-:s828000
+:N828000
     a skos:Concept ;
-    skos:broader :s820000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N820000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "828000" ;
     skos:prefLabel "Musikinstrumente"@de .
 
-:s840000
+:N840000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s8 ;
-    skos:narrower :s840100, :s841000, :s842000, :s843000, :s844000, :s844200, :s844500, :s845000, :s846000, :s847000, :s847500, :s848000, :s849000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N8 ;
+    skos:narrower :N840100, :N841000, :N842000, :N843000, :N844000, :N844200, :N844500, :N845000, :N846000, :N847000, :N847500, :N848000, :N849000 ;
     skos:notation "840000" ;
     skos:prefLabel "Kunst. Architektur"@de .
 
-:s840100
+:N840100
     a skos:Concept ;
-    skos:broader :s840000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N840000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "840100" ;
     skos:prefLabel "Kunst. Architektur - Allgemeines"@de .
 
-:s841000
+:N841000
     a skos:Concept ;
-    skos:broader :s840000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s841020, :s841040, :s841050, :s841060, :s841070, :s841080, :s841090 ;
+    skos:broader :N840000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N841020, :N841040, :N841050, :N841060, :N841070, :N841080, :N841090 ;
     skos:notation "841000" ;
     skos:prefLabel "Kunst"@de .
 
-:s841020
+:N841020
     a skos:Concept ;
-    skos:broader :s841000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N841000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "841020" ;
     skos:prefLabel "Kunsterziehung"@de .
 
-:s841040
+:N841040
     a skos:Concept ;
-    skos:broader :s841000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N841000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "841040" ;
     skos:prefLabel "Kunstmuseen und Kunstsammlungen"@de .
 
-:s841050
+:N841050
     a skos:Concept ;
-    skos:broader :s841000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N841000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "841050" ;
     skos:prefLabel "Kunstgalerien"@de .
 
-:s841060
+:N841060
     a skos:Concept ;
-    skos:broader :s841000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N841000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "841060" ;
     skos:prefLabel "Kunstausstellungen"@de .
 
-:s841070
+:N841070
     a skos:Concept ;
-    skos:broader :s841000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N841000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "841070" ;
     skos:prefLabel "Künstler"@de .
 
-:s841080
+:N841080
     a skos:Concept ;
-    skos:broader :s841000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N841000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "841080" ;
     skos:prefLabel "Künstlervereinigungen"@de .
 
-:s841090
+:N841090
     a skos:Concept ;
-    skos:broader :s841000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s841095 ;
+    skos:broader :N841000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N841095 ;
     skos:notation "841090" ;
     skos:prefLabel "Kunstförderung"@de .
 
-:s841095
+:N841095
     a skos:Concept ;
-    skos:broader :s841090 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N841090 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "841095" ;
     skos:prefLabel "Kunstpreise"@de .
 
-:s842000
+:N842000
     a skos:Concept ;
-    skos:broader :s840000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N840000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "842000" ;
     skos:prefLabel "Kunstgeschichte"@de .
 
-:s843000
+:N843000
     a skos:Concept ;
-    skos:broader :s840000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s843010, :s843020, :s843040, :s843050, :s843060, :s843090 ;
+    skos:broader :N840000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N843010, :N843020, :N843040, :N843050, :N843060, :N843090 ;
     skos:notation "843000" ;
     skos:prefLabel "Architektur"@de .
 
-:s843010
+:N843010
     a skos:Concept ;
-    skos:broader :s843000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N843000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "843010" ;
     skos:prefLabel "Baukonstruktion. Bautechnik"@de .
 
-:s843020
+:N843020
     a skos:Concept ;
-    skos:broader :s843000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N843000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "843020" ;
     skos:prefLabel "Öffentliche Gebäude"@de .
 
-:s843040
+:N843040
     a skos:Concept ;
-    skos:broader :s843000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s843042, :s843044, :s843046 ;
+    skos:broader :N843000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N843042, :N843044, :N843046 ;
     skos:notation "843040" ;
     skos:prefLabel "Büro-, Geschäfts-, Industriebauten"@de .
 
-:s843042
+:N843042
     a skos:Concept ;
-    skos:broader :s843040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N843040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "843042" ;
     skos:prefLabel "Bürohäuser"@de .
 
-:s843044
+:N843044
     a skos:Concept ;
-    skos:broader :s843040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N843040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "843044" ;
     skos:prefLabel "Geschäftshäuser"@de .
 
-:s843046
+:N843046
     a skos:Concept ;
-    skos:broader :s843040 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N843040 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "843046" ;
     skos:prefLabel "Industriebauten"@de .
 
-:s843050
+:N843050
     a skos:Concept ;
-    skos:broader :s843000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N843000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "843050" ;
     skos:prefLabel "Bauernhäuser"@de .
 
-:s843060
+:N843060
     a skos:Concept ;
-    skos:broader :s843000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N843000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "843060" ;
     skos:prefLabel "Wohnhäuser"@de .
 
-:s843090
+:N843090
     a skos:Concept ;
-    skos:broader :s843000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N843000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "843090" ;
     skos:prefLabel "Architekten"@de .
 
-:s844000
+:N844000
     a skos:Concept ;
-    skos:broader :s840000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s844010, :s844020, :s844030, :s844040, :s844050, :s844060, :s844070, :s844080 ;
+    skos:broader :N840000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N844010, :N844020, :N844030, :N844040, :N844050, :N844060, :N844070, :N844080 ;
     skos:notation "844000" ;
     skos:prefLabel "Baudenkmäler. Kunstwerke"@de .
 
-:s844010
+:N844010
     a skos:Concept ;
-    skos:broader :s844000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N844000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "844010" ;
     skos:prefLabel "Inventare"@de .
 
-:s844020
+:N844020
     a skos:Concept ;
-    skos:broader :s844000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N844000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "844020" ;
     skos:prefLabel "Baustile"@de .
 
-:s844030
+:N844030
     a skos:Concept ;
-    skos:broader :s844000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N844000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "844030" ;
     skos:prefLabel "Kirchenbau. Kirchenausstattung"@de .
 
-:s844040
+:N844040
     a skos:Concept ;
-    skos:broader :s844000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N844000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "844040" ;
     skos:prefLabel "Burgen. Schlösser"@de .
 
-:s844050
+:N844050
     a skos:Concept ;
-    skos:broader :s844000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N844000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "844050" ;
     skos:prefLabel "Profanarchitektur"@de .
 
-:s844060
+:N844060
     a skos:Concept ;
-    skos:broader :s844000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N844000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "844060" ;
     skos:prefLabel "Park- und Gartenanlagen"@de .
 
-:s844070
+:N844070
     a skos:Concept ;
-    skos:broader :s844000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N844000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "844070" ;
     skos:prefLabel "Brunnen"@de .
 
-:s844080
+:N844080
     a skos:Concept ;
-    skos:broader :s844000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N844000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "844080" ;
     skos:prefLabel "Denkmäler"@de .
 
-:s844200
+:N844200
     a skos:Concept ;
-    skos:broader :s840000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N840000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "844200" ;
     skos:prefLabel "Denkmalpflege. Denkmalschutz"@de .
 
-:s844500
+:N844500
     a skos:Concept ;
-    skos:broader :s840000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N840000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "844500" ;
     skos:prefLabel "Stadtbaukunst"@de .
 
-:s845000
+:N845000
     a skos:Concept ;
-    skos:broader :s840000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N840000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "845000" ;
     skos:prefLabel "Plastik"@de .
 
-:s846000
+:N846000
     a skos:Concept ;
-    skos:broader :s840000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N840000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "846000" ;
     skos:prefLabel "Malerei"@de .
 
-:s847000
+:N847000
     a skos:Concept ;
-    skos:broader :s840000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N840000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "847000" ;
     skos:prefLabel "Zeichnung"@de .
 
-:s847500
+:N847500
     a skos:Concept ;
-    skos:broader :s840000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N840000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "847500" ;
     skos:prefLabel "Graphik"@de .
 
-:s848000
+:N848000
     a skos:Concept ;
-    skos:broader :s840000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N840000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "848000" ;
     skos:prefLabel "Photographie"@de .
 
-:s849000
+:N849000
     a skos:Concept ;
-    skos:broader :s840000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s849020, :s849030, :s849040, :s849050, :s849060, :s849070, :s849080 ;
+    skos:broader :N840000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N849020, :N849030, :N849040, :N849050, :N849060, :N849070, :N849080 ;
     skos:notation "849000" ;
     skos:prefLabel "Kunsthandwerk"@de .
 
-:s849020
+:N849020
     a skos:Concept ;
-    skos:broader :s849000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N849000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "849020" ;
     skos:prefLabel "Gold- und Silberschmiedekunst. Schmuck"@de .
 
-:s849030
+:N849030
     a skos:Concept ;
-    skos:broader :s849000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s849031, :s849032, :s849034 ;
+    skos:broader :N849000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N849031, :N849032, :N849034 ;
     skos:notation "849030" ;
     skos:prefLabel "Metallguß"@de .
 
-:s849031
+:N849031
     a skos:Concept ;
-    skos:broader :s849030 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N849030 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "849031" ;
     skos:prefLabel "Eisenguß"@de .
 
-:s849032
+:N849032
     a skos:Concept ;
-    skos:broader :s849030 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N849030 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "849032" ;
     skos:prefLabel "Bronzekunst"@de .
 
-:s849034
+:N849034
     a skos:Concept ;
-    skos:broader :s849030 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N849030 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "849034" ;
     skos:prefLabel "Zinngerät"@de .
 
-:s849040
+:N849040
     a skos:Concept ;
-    skos:broader :s849000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N849000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "849040" ;
     skos:prefLabel "Keramik"@de .
 
-:s849050
+:N849050
     a skos:Concept ;
-    skos:broader :s849000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s849052, :s849054, :s849056 ;
+    skos:broader :N849000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N849052, :N849054, :N849056 ;
     skos:notation "849050" ;
     skos:prefLabel "Porzellan. Fayence. Glas"@de .
 
-:s849052
+:N849052
     a skos:Concept ;
-    skos:broader :s849050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N849050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "849052" ;
     skos:prefLabel "Porzellan"@de .
 
-:s849054
+:N849054
     a skos:Concept ;
-    skos:broader :s849050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N849050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "849054" ;
     skos:prefLabel "Fayence"@de .
 
-:s849056
+:N849056
     a skos:Concept ;
-    skos:broader :s849050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N849050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "849056" ;
     skos:prefLabel "Glas"@de .
 
-:s849060
+:N849060
     a skos:Concept ;
-    skos:broader :s849000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N849000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "849060" ;
     skos:prefLabel "Hausrat"@de .
 
-:s849070
+:N849070
     a skos:Concept ;
-    skos:broader :s849000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N849000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "849070" ;
     skos:prefLabel "Möbel"@de .
 
-:s849080
+:N849080
     a skos:Concept ;
-    skos:broader :s849000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s849082, :s849084, :s849086 ;
+    skos:broader :N849000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N849082, :N849084, :N849086 ;
     skos:notation "849080" ;
     skos:prefLabel "Textilien. Teppiche. Tapeten"@de .
 
-:s849082
+:N849082
     a skos:Concept ;
-    skos:broader :s849080 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N849080 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "849082" ;
     skos:prefLabel "Textilkunst. Mode"@de .
 
-:s849084
+:N849084
     a skos:Concept ;
-    skos:broader :s849080 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N849080 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "849084" ;
     skos:prefLabel "Teppichknüpferei. Teppichweberei"@de .
 
-:s849086
+:N849086
     a skos:Concept ;
-    skos:broader :s849080 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N849080 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "849086" ;
     skos:prefLabel "Tapeten"@de .
 
-:s860000
+:N860000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s8 ;
-    skos:narrower :s860100, :s861000, :s865000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N8 ;
+    skos:narrower :N860100, :N861000, :N865000 ;
     skos:notation "860000" ;
     skos:prefLabel "Buch und Bibliothek"@de .
 
-:s860100
+:N860100
     a skos:Concept ;
-    skos:broader :s860000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N860000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "860100" ;
     skos:prefLabel "Buch und Bibliothek - Allgemeines"@de .
 
-:s861000
+:N861000
     a skos:Concept ;
-    skos:broader :s860000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s861010, :s861020, :s861030, :s861040, :s861050, :s861060 ;
+    skos:broader :N860000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N861010, :N861020, :N861030, :N861040, :N861050, :N861060 ;
     skos:notation "861000" ;
     skos:prefLabel "Buch"@de .
 
-:s861010
+:N861010
     a skos:Concept ;
-    skos:broader :s861000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N861000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "861010" ;
     skos:prefLabel "Schriftgeschichte"@de .
 
-:s861020
+:N861020
     a skos:Concept ;
-    skos:broader :s861000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N861000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "861020" ;
     skos:prefLabel "Handschriften"@de .
 
-:s861030
+:N861030
     a skos:Concept ;
-    skos:broader :s861000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N861000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "861030" ;
     skos:prefLabel "Buchgeschichte"@de .
 
-:s861040
+:N861040
     a skos:Concept ;
-    skos:broader :s861000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N861000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "861040" ;
     skos:prefLabel "Druckgeschichte"@de .
 
-:s861050
+:N861050
     a skos:Concept ;
-    skos:broader :s861000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s861052, :s861054, :s861056 ;
+    skos:broader :N861000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N861052, :N861054, :N861056 ;
     skos:notation "861050" ;
     skos:prefLabel "Verlage"@de .
 
-:s861052
+:N861052
     a skos:Concept ;
-    skos:broader :s861050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N861050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "861052" ;
     skos:prefLabel "Urheberrecht"@de .
 
-:s861054
+:N861054
     a skos:Concept ;
-    skos:broader :s861050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N861050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "861054" ;
     skos:prefLabel "Verlagsrecht"@de .
 
-:s861056
+:N861056
     a skos:Concept ;
-    skos:broader :s861050 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N861050 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "861056" ;
     skos:prefLabel "Verleger"@de .
 
-:s861060
+:N861060
     a skos:Concept ;
-    skos:broader :s861000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N861000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "861060" ;
     skos:prefLabel "Buchhandel"@de .
 
-:s865000
+:N865000
     a skos:Concept ;
-    skos:broader :s860000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s865010, :s865020, :s865030, :s865040, :s865050, :s865060, :s865070, :s865080, :s865090 ;
+    skos:broader :N860000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N865010, :N865020, :N865030, :N865040, :N865050, :N865060, :N865070, :N865080, :N865090 ;
     skos:notation "865000" ;
     skos:prefLabel "Bibliotheken"@de .
 
-:s865010
+:N865010
     a skos:Concept ;
-    skos:broader :s865000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N865000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "865010" ;
     skos:prefLabel "Bibliotheksrecht"@de .
 
-:s865020
+:N865020
     a skos:Concept ;
-    skos:broader :s865000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N865000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "865020" ;
     skos:prefLabel "Bibliotheksgeschichte"@de .
 
-:s865030
+:N865030
     a skos:Concept ;
-    skos:broader :s865000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N865000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "865030" ;
     skos:prefLabel "Bibliotheksplanung"@de .
 
-:s865040
+:N865040
     a skos:Concept ;
-    skos:broader :s865000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N865000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "865040" ;
     skos:prefLabel "Wissenschaftliche Bibliotheken"@de .
 
-:s865050
+:N865050
     a skos:Concept ;
-    skos:broader :s865000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N865000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "865050" ;
     skos:prefLabel "Öffentliche Bibliotheken"@de .
 
-:s865060
+:N865060
     a skos:Concept ;
-    skos:broader :s865000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N865000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "865060" ;
     skos:prefLabel "Spezialbibliotheken"@de .
 
-:s865070
+:N865070
     a skos:Concept ;
-    skos:broader :s865000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N865000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "865070" ;
     skos:prefLabel "Schulbibliotheken"@de .
 
-:s865080
+:N865080
     a skos:Concept ;
-    skos:broader :s865000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N865000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "865080" ;
     skos:prefLabel "Privatbibliotheken"@de .
 
-:s865090
+:N865090
     a skos:Concept ;
-    skos:broader :s865000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N865000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "865090" ;
     skos:prefLabel "Bibliothekare"@de .
 
-:s880000
+:N880000
     a skos:Concept ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:broader :s8 ;
-    skos:narrower :s880100, :s882000, :s884000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:broader :N8 ;
+    skos:narrower :N880100, :N882000, :N884000 ;
     skos:notation "880000" ;
     skos:prefLabel "Publizistik. Information und Dokumentation"@de .
 
-:s880100
+:N880100
     a skos:Concept ;
-    skos:broader :s880000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N880000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "880100" ;
     skos:prefLabel "Publizistik. Information und Dokumentation - Allgemeines"@de .
 
-:s882000
+:N882000
     a skos:Concept ;
-    skos:broader :s880000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s882020, :s882030, :s882040, :s882060, :s882090 ;
+    skos:broader :N880000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N882020, :N882030, :N882040, :N882060, :N882090 ;
     skos:notation "882000" ;
     skos:prefLabel "Publizistik"@de .
 
-:s882020
+:N882020
     a skos:Concept ;
-    skos:broader :s882000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
-    skos:narrower :s882022, :s882024, :s882026 ;
+    skos:broader :N882000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
+    skos:narrower :N882022, :N882024, :N882026 ;
     skos:notation "882020" ;
     skos:prefLabel "Presse"@de .
 
-:s882022
+:N882022
     a skos:Concept ;
-    skos:broader :s882020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N882020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "882022" ;
     skos:prefLabel "Presserecht"@de .
 
-:s882024
+:N882024
     a skos:Concept ;
-    skos:broader :s882020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N882020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "882024" ;
     skos:prefLabel "Zeitungen"@de .
 
-:s882026
+:N882026
     a skos:Concept ;
-    skos:broader :s882020 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N882020 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "882026" ;
     skos:prefLabel "Zeitschriften"@de .
 
-:s882030
+:N882030
     a skos:Concept ;
-    skos:broader :s882000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N882000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "882030" ;
     skos:prefLabel "Audiovisuelle Medien"@de .
 
-:s882040
+:N882040
     a skos:Concept ;
-    skos:broader :s882000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N882000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "882040" ;
     skos:prefLabel "Rundfunk"@de .
 
-:s882060
+:N882060
     a skos:Concept ;
-    skos:broader :s882000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N882000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "882060" ;
     skos:prefLabel "Fernsehen"@de .
 
-:s882090
+:N882090
     a skos:Concept ;
-    skos:broader :s882000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N882000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "882090" ;
     skos:prefLabel "Journalisten"@de .
 
-:s884000
+:N884000
     a skos:Concept ;
-    skos:broader :s880000 ;
-    skos:inScheme <http://purl.org/lobid/nwbib> ;
+    skos:broader :N880000 ;
+    skos:inScheme <https://nwbib.de/subjects> ;
     skos:notation "884000" ;
     skos:prefLabel "Information und Dokumentation"@de .

--- a/nwbib/nwbib.ttl
+++ b/nwbib/nwbib.ttl
@@ -2,18 +2,18 @@
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix vann: <http://purl.org/vocab/vann/> .
-@prefix : <http://purl.org/lobid/nwbib#> .
+@prefix : <https://nwbib.de/subjects#> .
 
-<http://purl.org/lobid/nwbib>
+<https://nwbib.de/subjects>
     a skos:ConceptScheme ;
     vann:preferredNamespacePrefix "nwbib" ;
     dct:title "Sachsystematik der Nordrhein-Westfälischen Bibliographie"@de , "Classification scheme of the North Rhine-Westphalian bibliography"@en ;
     dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
     dct:description "This classification was created for use in the North Rhine-Westphalian bibliography. The initial transformation to SKOS was carried out by Felix Ostrowski for the hbz." ;
     dct:issued "2014-01-28" ;
-    dct:modified "2017-10-09" ;
-    dct:publisher <http://lobid.org/organisation/DE-605> ;
-    vann:preferredNamespaceUri "http://purl.org/lobid/nwbib#" ;
+    dct:modified "2022-01-13" ;
+    dct:publisher <http://lobid.org/organisations/DE-605> ;
+    vann:preferredNamespaceUri "https://nwbib.de/subjects#" ;
     skos:hasTopConcept :s1, :s2, :s4, :s5, :s6, :s7, :s8 .
 
 :s1


### PR DESCRIPTION
For sake of consistency, analogous to the already changed NWBib spatial namespace.